### PR TITLE
Validation fix: paragraph <div> turned into <p>

### DIFF
--- a/data/lit0001/__cts__.xml
+++ b/data/lit0001/__cts__.xml
@@ -2,4 +2,6 @@
 <ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:mayaLit:lit0001">
     <!-- Provides the name of the textgroup in each of the languages used in the works. -->
   <ti:groupname xml:lang="eng">Maya Literature</ti:groupname>
+  <ti:groupname xml:lang="spa">Literatura maya</ti:groupname>
+  <ti:groupname xml:lang="quc">Uch'ob'oj maya </ti:groupname>
  </ti:textgroup>

--- a/data/lit0001/pw0001/lit0001.pw0001.popolwuj-quc.xml
+++ b/data/lit0001/pw0001/lit0001.pw0001.popolwuj-quc.xml
@@ -119,12 +119,11 @@
                     <lb n="44"/>rech zaquil amaquil, za<pc> –</pc>
                     <lb n="45"/>quil al, zaquil qahol, ah<pc> –</pc>
                     <lb n="46"/>biz, ahnaoh chirech ronohel
-                    <!-- <pb xml:id="xom-f01-s2" /> -->
+                    <pb xml:id="xom-f01-s2" />
                     <lb n="47"/>ato qol vi cah vleu cho palo
                     <lb n="48"/>
                 </p>
                 <p n="3">
-                    <!-- <p xml:id="p03"> -->
                     <lb n="2" rend="center"/><hi rend="large">ARE V ꜨIHOXIC VAE</hi>
                     <lb n="3" rend="center"/>Cacaꜩinin oc, caca chamam oc
                     <lb n="4" rend="center"/>caꜩinonic cacazilanic, caca
@@ -133,7 +132,6 @@
                     <!-- </p> -->
                </p>
                <p n="4">
-                    <!-- <p xml:id="p04"> -->
                     <lb n="7" rend="indent"/><hi rend="large">V</hi>ae cute nabe ꜩih nabe vch<pc> –</pc>
                     <lb n="8"/>an. mahabi oꜫ hun vinac, hun
                     <lb n="9"/>chicop, ꜩiquin, car, tap, che
@@ -160,10 +158,8 @@
                     <lb n="30"/>cut xax qo vi ri cah qonaipu<pc> –</pc>
                     <lb n="31"/>ch <rs ana="UK'U'X_KAJ">vqux cah</rs> are vbi ri ca<pc> –</pc>
                     <lb n="32"/>bauil chuqhaxic.
-                    <!-- </p> -->
                 </p>
                 <p n="5">
-                    <!-- <p xml:id="p05"> -->
                     <lb n="33" rend="indent"/><hi rend="large">T</hi>a xpe cut vꜩih varal xul
                     <lb n="34"/>cuq ri <rs ana="TEPEW_Q'UKUMATZ">tepeu gucumaꜩ</rs> varal
                     <lb n="35"/>chi quecumal chi aꜫabal xqh<pc> –</pc>
@@ -178,7 +174,7 @@
                     <lb n="44"/>ch qazlem vinaquirem chi
                     <lb n="45"/>queꜫumal, chi aꜫabal, rumal
                     <lb n="46"/>ri <rs ana="UK'U'X_KAJ">vqux cah huracan</rs> vbi,
-                    <!-- <pb xml:id="xom-f02-s1"/> -->
+                    <pb xml:id="xom-f02-s1"/>
                     <lb n="1"/><rs ana="KAQUILJA_JUN_RAQAN">caculha huracan</rs> nabe, vcab
                     <lb n="2"/>cut <rs ana="CH'IPI_KAQULJA">chipa caculha</rs>, roxchic
                     <lb n="3"/><rs ana="RAXA_KAQULJA">raxa caculha</rs> chi e cu oxib
@@ -226,12 +222,10 @@
                     <lb n="45"/>leuh chupan ha. quehe cut
                     <lb n="46"/>vnaohixic ri ta xquinohih ta
                     <lb n="47"/>xquibizoh ruꜩinic vbana
-                    <!-- <pb xml:id="xom-f02-s2"/> -->
+                    <pb xml:id="xom-f02-s2"/>
                     <lb n="1"/>tahic cumal.
-                    <!-- </p> -->
                 </p>
                 <p n="6">
-                    <!-- <p xml:id="p06"> -->
                     <note><num>2</num></note>
                     <lb n="2" rend="indent"/><hi rend="large">T</hi>a xquinohih chic vchicop<pc> –</pc>
                     <lb n="3"/>il huyub chahal re quichelah
@@ -264,10 +258,8 @@
                     <lb n="30"/>ri vleu xuyao <rs ana="ALOM">alom</rs>, <rs ana="K'AJOLOM">qaho<pc> –</pc>
                     <lb n="31"/>lom</rs>. xuꜩininaca chic ronohel
                     <lb n="32"/>ri queh ꜩiquin
-                    <!-- </p> -->
                 </p>
                 <p n="7">
-                    <!-- <p xml:id="p07"> -->
                     <lb n="33" rend="indent"/><hi rend="large">T</hi>a xevqhax chicut rÿ queh
                     <lb n="34"/>ꜩiquin rumal <rs ana="TZACOL">ꜩacol</rs> <rs ana="BITOL">bitol</rs> <rs ana="ALOM">a<pc> –</pc>
                     <lb n="35"/>lom</rs>, <rs ana="K'AJOLOM">qaholom</rs>: quixqhauoc ,
@@ -282,7 +274,7 @@
                     <lb n="44"/>racan</rs>, <rs ana="CH'IPI_KAQULJA">chipi caculha</rs>, <rs ana="RAXA_KAQULJA">raxa
                     <lb n="45"/>caculha</rs>, <rs ana="UK'U'X_KAJ">vqux cah</rs>, <rs ana="UK'U'X_ULEW">vquxvle<pc> –</pc>
                     <lb n="46"/>uh</rs>, <rs ana="TZ'AQOL">ꜩacol</rs>, <rs ana="BITOL">bitol</rs>, <rs ana="ALOM">alom</rs> <rs ana="K'AJOLOM">qaholõ</rs>
-                    <!-- <pb xml:id="xom-f03-s1"/> -->
+                    <pb xml:id="xom-f03-s1"/>
                     <lb n="1"/>quixqhaoc cohiziquih, cohiqui<pc> –</pc>
                     <lb n="2"/>hila, xevqhaxic. macu xuꜩinic
                     <lb n="3"/>xeqhauic, queheta ri vinac, xa
@@ -331,7 +323,7 @@
                     <lb n="45"/>ziquixoc, ta cohnabax puch
                     <lb n="46"/>chuvach vleuh. mi xcatiho
                     <lb n="47"/>chirech rinabe ca ꜩac, ca
-                    <!-- <pb xml:id="xom-f03-s2"/> -->
+                    <pb xml:id="xom-f03-s2"/>
                     <lb n="1"/>bit maui mi xuꜩinic ca quihilo<pc> –</pc>
                     <lb n="2"/>xic, ca calaixic puch cumal, que<pc> –</pc>
                     <lb n="3"/>he cut catiha vi vbanic ah nim
@@ -368,10 +360,8 @@
                     <lb n="34"/>vqhaxic cumal ri <rs ana="TZ'AQOL">ꜩacol</rs> <rs ana="BITOL">bitol</rs>
                     <lb n="35"/>are qui bi ri <rs ana="XPIYAKOK">xpiyacoc</rs>, <rs ana="IXMUKANE">xmuca<pc> –</pc>
                     <lb n="36"/>ne</rs>
-                    <!-- </p> -->
                 </p>
                 <p n="8">
-                    <!-- <p xml:id="p08"> -->
                     <lb n="37" rend="indent"/><hi rend="large">X</hi>eqha qu ri <rs ana="UK'U'X_KAJ">huracan</rs> ruq <rs ana="TEPEW_Q'UKUMATZ">te<pc> –</pc>
                     <lb n="38"/>peu gucumaꜩ</rs> ta xquibih chire<pc> –</pc>
                     <lb n="39"/>ch ahquih ah bit enic vachi<pc> –</pc>
@@ -383,7 +373,7 @@
                     <lb n="45"/>catit camam <rs ana="XPIYAKOK">xpiyacoc</rs>, <rs ana="IXMUKANE">xmuca
                     <lb n="46"/>ne</rs> chatah ta chavaxoc, ta zaqui<pc> –</pc>
                     <lb n="47"/>roc ca ziquixic, ca toquexic ca
-                    <!-- <pb xml:id="xom-f04-s1"/> -->
+                    <pb xml:id="xom-f04-s1"/>
                     <lb n="1"/>nabaxic rumal vinac ꜩac, vinac
                     <lb n="2"/>bit, vinac poy, vinac anom cha
                     <lb n="3"/>ta chuxoc chicutun ibi <rs ana="JUNAJPU_WUCH">hunahpu
@@ -431,7 +421,7 @@
                     <lb n="45"/>habi qui qux ma pu habi qui<pc> –</pc>
                     <lb n="46"/>naoh maui natal cah ꜩac
                     <lb n="47"/>cah bit xaloc xebinic, xecha<pc> –</pc>
-                    <!-- <pb xml:id="xom-f04-s2"/> -->
+                    <pb xml:id="xom-f04-s2"/>
                     <note><num>4</num></note>
                     <lb n="1"/>canic maui xquinatah chic ri <rs ana="UK'U'X_KAJ">v<pc> –</pc>
                     <lb n="2"/>qux cah</rs> quehe cut xepah chivi
@@ -448,10 +438,8 @@
                     <lb n="13"/>tol</rs> alai quech, quxlaai quech
                     <lb n="14"/>enabe ꜩaꜩ chivinac xevxic
                     <lb n="15"/>varal chuvach vleu
-                    <!-- </p> -->
                 </p>
                 <p n="9">
-                    <!-- <p xml:id="p09"> -->
                     <lb n="16" rend="indent"/><hi rend="large">C</hi>atecut qui quÿzic chic qui
                     <lb n="17"/>mayxic qui cutuxic puch xe
                     <lb n="18"/>camizax chic poy aham che
@@ -485,7 +473,7 @@
                     <lb n="45"/>chuti chicop nima chicop xcut
                     <lb n="46"/>qui vach rumal che abah. x<pc> –</pc>
                     <lb n="47"/>qhauic ronohel qui quebal<pc> –</pc>
-                    <!-- <pb xml:id="xom-f05-s1"/> -->
+                    <pb xml:id="xom-f05-s1"/>
                     <lb n="1"/>quixot, qui lac, qui boh, qui ꜩi
                     <lb n="2"/>quieaa, haruh pala ronohel
                     <note place="margin-left" anchored="true">
@@ -538,7 +526,7 @@
                     <lb n="45"/>ha xa chiu vlih ha queꜩac
                     <lb n="46"/>vloc, querah acan chuvi
                     <lb n="47"/>che queqhaquix vloc ruma che
-                    <!-- <pb xml:id="xom-f05-s2"/> -->
+                    <pb xml:id="xom-f05-s2"/>
                     <lb n="1"/>querah oc pahul xa chiyuch
                     <lb n="2"/>hul chi qui vach; que he cut
                     <lb n="3"/>vcayohic vinac ꜩac vinac
@@ -553,10 +541,8 @@
                     <lb n="12"/>heri vinac chivachinic retal
                     <lb n="13"/>hule vinac ꜩac, vinac bit
                     <lb n="14"/>xapoy, xapu ahamche.
-                    <!-- </p> -->
                 </p>
                 <p n="10">
-                    <!-- <p xml:id="p10"> -->
                     <lb n="15" rend="indent"/><hi rend="large">A</hi>re cut xa hubic zac na
                     <lb n="15.1"/>tanoh vvachvleu mahabi
                     <lb n="16"/>quih hun cut cunimarizah
@@ -592,7 +578,7 @@
                     <lb n="44"/>rizah rib rivxic vpuvaC
                     <lb n="45"/>xere cut tocol vi v vach ri
                     <lb n="46"/>chicube vi mana ronohelta
-                    <!-- <pb xml:id="xom-f06-s1"/> -->
+                    <pb xml:id="xom-f06-s1"/>
                     <lb n="1"/>vxecah copon vi vvach. maha
                     <lb n="2"/>cut qui quiloc v vach quih, ic
                     <lb n="3"/>chumil mahaoc cazaquiroc
@@ -606,10 +592,8 @@
                     <lb n="11"/>ta xcamic <rs ana="WUQUB_KAKIX">vucub caquix</rs> ta
                     <lb n="12"/>xchacatahic, ta xbanatahic vi<pc> –</pc>
                     <lb n="13"/>nac rumal <rs ana="TZ'AQOL">ahꜩac</rs>, <rs ana="BITOL">ahbit</rs>.
-                    <!-- </p> -->
                 </p> 
                 <p n="11">
-                    <!-- p xml:id="p11" -->
                     <lb n="14" rend="indent"/><hi rend="large">V</hi>ae vxe vchacatahic v yi<pc> –</pc>
                     <lb n="15"/>coxic chi puch v quih <rs ana="WUQUB_KAKIX">vucub
                     <lb n="16"/>ca quix</rs> cumal e <rs ana="KA'IB_K'AJOLAB">caib qaholab</rs>
@@ -6048,10 +6032,8 @@
                     <lb n="8"/>puch arecut vbi ahauab va
                     <lb n="9"/>chupan nimha xacahib vnim
                     <lb n="10"/>ha.
-                    <!-- </p> -->
                 </p>
                 <p n="101">
-                    <!-- <p> -->
                     <lb n="11"/><rs ana="AJAW_AJTZIK_WINAQ"><hi rend="large">A</hi>h ꜩic vinac ahau</rs> vbi nabeahau
                     <lb n="12" rend="indent"/>hun vnim ha
                     <lb n="13"/><rs ana="AJAW_LOLMET"><hi rend="large">L</hi>olmet ahau</rs> ucabahau hun
@@ -6062,10 +6044,8 @@
                     <lb n="17"/><rs ana="AJAW_JAQAWITZ"><hi rend="large">H</hi>acaviꜩ</rs> cut vcah ahau hun
                     <lb n="18" rend="indent"/>vnim ha chicahibcut nimha
                     <lb n="19" rend="indent"/>chuvach <rs ana="AJAW_K'ICHE'">ahau quiche</rs>
-                    <!-- </p> -->
                 </p>
                 <p n="102">
-                    <!-- <p xml:id="p96"> -->
                     <lb n="20" rend="indent"/><hi rend="large">A</hi>re curi e oxib chinim chocoh
                     <lb n="21"/>queheri e cahauixel rumal ro<pc> –</pc>
                     <lb n="22"/>nohel <rs ana="AJAW_K'ICHE'">ahavab quiche</rs> xahun
@@ -6073,10 +6053,8 @@
                     <lb n="24"/>chocohib. e alanel, e vchuch ꜩih
                     <lb n="25"/>evcahau ꜩih nim zcaquin vqo<pc> –</pc>
                     <lb n="26"/>heic eoxib chichocohib
-                    <!-- </p> -->
                 </p>
                 <p n="103">
-                    <!-- <p xml:id="p97"> -->
                     <lb n="27" rend="indent"/><hi rend="large">N</hi>im chocohcut chuvach <rs ana="NIJA'IB">nihaib</rs>
                     <lb n="28"/>vcab curi. <rs ana="AJAW_NIM_CH'OKOJ">nimchocoh ahau</rs> chuva<pc> –</pc>
                     <lb n="29"/>ch <rs ana="AJAW_K'ICHE'">ahau quiche</rs> rox nim chocoh
@@ -6098,7 +6076,6 @@
                     <lb/>
                     <lb/>
                     <lb/>
-                    <!-- </p> -->
                 </p> 
             </div>
         </body>

--- a/data/lit0001/pw0001/lit0001.pw0001.popolwuj-quc.xml
+++ b/data/lit0001/pw0001/lit0001.pw0001.popolwuj-quc.xml
@@ -129,7 +129,7 @@
                     <lb n="4" rend="center"/>caꜩinonic cacazilanic, caca
                     <lb n="5" rend="center"/>lolinic, catolona puch v
                     <lb n="6" rend="center"/>pa cah.
-                    <!-- </p> -->
+                    
                </p>
                <p n="4">
                     <lb n="7" rend="indent"/><hi rend="large">V</hi>ae cute nabe ꜩih nabe vch<pc> –</pc>
@@ -1547,7 +1547,6 @@
                     <lb n="18"/>vbi.
                 </p>
                 <p n="21">
-                    <!-- <p xml:id="p21"> -->
                     <lb n="19" rend="indent"/><hi rend="large">A</hi>re cut ta xuta hun <rs ana="IXKIK'">capoh vme<pc> –</pc>
                     <lb n="20"/>al</rs> hun ahau <rs ana="KUCHUMA_KIK'">cuchumaquic</rs> vbi v
                     <lb n="21"/>cahau <rs ana="IXKIK'">xquic</rs> cut vbi ri capoh ta
@@ -1617,10 +1616,8 @@
                     <lb n="31"/>caquib ic ta xnauachil rumal
                     <lb n="32"/>vcahau ri <rs ana="KUCHUMA_KIK'">cuchumaquic</rs> vbi v
                     <lb n="33"/>cahau
-                    <!-- </p> -->
                 </p>
                 <p n="22">
-                    <!-- <p xml:id="p22"> -->
                     <lb n="34" rend="indent"/><hi rend="large">C</hi>ate puch vnatahic capoh ru<pc> –</pc>
                     <lb n="35"/>mal vcahau ta xil ri ral cochic
                     <lb n="36"/>ta <rs ana="IXKIK'">xquicuch</rs> cut qui naoh cono<pc> –</pc>
@@ -1717,10 +1714,10 @@
                     <lb n="27"/>chacatah vi rahaual <rs ana="XIBALBA">xibalba</rs>
                     <lb n="28"/>ri rumal <rs ana="IXKIK'">capoh</rs> xemoyvachixic
                     <lb n="29"/>conohel.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="23">
-                    <!-- <p xml:id="p23"> -->
+                    
                     <lb n="30" rend="indent"/><hi rend="large">A</hi>re cut e qo ri <rs ana="IXMUKANE">vchuch</rs> <rs ana="JUN_BATZ'">hun baꜩ</rs>
                     <lb n="31"/><rs ana="JUN_CHOWEN">hun choven</rs> ta xul ri ixoc <rs ana="IXKIK'">xquic</rs> v
                     <lb n="32"/>bi. ta xul cut ri ixoc <rs ana="IXKIK'">xquic</rs> ruq
@@ -1799,16 +1796,16 @@
                     <lb n="6"/>tal ri quiꜩih vi chiat valib chivil
                     <lb n="7"/>china abanoh ri eqorivi enavinac
                     <lb n="8"/>chic xuqhax cut <rs ana="IXKIK'">capoh</rs>
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="24">
-                    <!-- <p xml:id="p24"> -->
+                    
                     <lb n="9" rend="indent"/><hi rend="large">A</hi>re chic xchicaꜩihoh calaxic
                     <lb n="10"/><rs ana="JUNAJPU">hun ahpu</rs> <rs ana="XBALAMKE">xbalanque</rs>
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="25">
-                    <!-- <p xml:id="p25"> -->
+                    
                     <lb n="11" rend="indent"/><hi rend="large">A</hi>re cut calaxic vae xchicabÿh
                     <lb n="12"/>ta xuric vquih calaxic taxalan
                     <lb n="13"/>puch ri <rs ana="IXKIK'">capoh</rs> <rs ana="IXKIK'">xquic</rs> vbi. macu xu
@@ -1947,10 +1944,10 @@
                     <lb n="40"/>qui quih xeqha cut cate puch x<pc> –</pc>
                     <lb n="41"/>quitiquiba zuanic, <rs ana="JUNAJPU">hun ahpu</rs> x coy
                     <lb n="42"/>xquizuah.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="26">
-                    <!-- <p xml:id="p26"> -->
+                    
                     <lb n="43" rend="indent"/><hi rend="large">C</hi>atepuch xebixanic xezuanic
                     <lb n="44"/>xe cohomanic ta vcamic riqui zu
                     <lb n="45"/>qui cohom ta xcube puch ri catit
@@ -2022,10 +2019,10 @@
                     <lb n="11"/>ch chic xavi xere e ahzu e ahbix
                     <lb n="12"/>nim chic xquibano ta xecoheic rug
                     <lb n="13"/>ratit rug pu quichuch
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="27">
-                    <!-- <p xml:id="p27"> -->
+                    
                     <lb n="14" rend="indent"/><hi rend="large">T</hi>a x quitiquiba chicut quibanoh
                     <lb n="15"/>qui cutbal quib chuvach catit chu<pc> –</pc>
                     <lb n="16"/>vachpu qui chuch nabe xquibano
@@ -2187,10 +2184,10 @@
                     <lb n="19"/>pixabah hunacab xcam qui na<pc> –</pc>
                     <lb n="20"/>oh ri <rs ana="JUNAJPU">hun ahpu</rs> <rs ana="XBALAMKE">xbalanque</rs> qui
                     <lb n="21"/>cutiquil quih xeoponic.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="28">
-                    <!-- <p xml:id="p28"> -->
+                    
                     <lb n="22" rend="indent"/><hi rend="large">M</hi>acu calah richo cucaam
                     <lb n="23"/>taxeoponic hunriyacalic xoc
                     <lb n="24"/>paha, huncu xoc xiquinha libah
@@ -2238,10 +2235,10 @@
                     <lb n="13"/>hunam cut xepe chic, enabe chu<pc> –</pc>
                     <lb n="14"/>vach catit quehe cut vcanaic quic
                     <lb n="15"/>ri.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="29">
-                    <!-- <p xml:id="p29"> -->
+                    
                     <lb n="16" rend="indent"/><hi rend="large">Q</hi>uequicot chicut xebec echaa
                     <lb n="17"/>hel, pahom nahtcu xechaahic qui
                     <lb n="18"/>tuquel xquimez rihom quicahau
@@ -2332,10 +2329,10 @@
                     <lb n="1"/><rs ana="PAJARO">vac</rs> co, <rs ana="PAJARO">vac</rs> co xqha roquibal <rs ana="PAJARO">vac</rs> co
                     <lb n="2"/>naquipa ri choquic petaca vvb xe
                     <lb n="3"/>qha.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="30">
-                    <!-- <p xml:id="p30"> -->
+                    
                     <lb n="4" rend="indent" /><hi rend="large">C</hi>atepuch xquivvbah ri <rs ana="PAJARO">vac</rs> qui<pc> –</pc>
                     <lb n="5"/>cutacal vbaca vvb chu baca vvach
                     <lb n="6"/>chizetet cut xcah vloc quiꜩih vi
@@ -2394,10 +2391,10 @@
                     <lb n="8"/>chiquiqux ta xquitao huzu xe<pc> –</pc>
                     <lb n="9"/>petic xeopon cut ruq <rs ana="IXMUKANE">catit</rs> xa
                     <lb n="10"/>e pixabai chire <rs ana="IXMUKANE">catit</rs> xebec.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="31">
-                    <!-- <p xml:id="p31"> -->
+                    
                     <lb n="11" rend="indent"/>ho na <rs ana="IXMUKANE">ixcatit</rs> xaohpixabay
                     <lb n="12"/>ive vae cute retal caꜩih xchicacanah
                     <lb n="13"/>huhun xchicatic chire
@@ -2720,10 +2717,10 @@
                     <lb n="19"/>chicu quib zacaric chic xeqha<pc> –</pc>
                     <lb n="20"/>vzbala xeqha <rs ana="KA'IB_K'AJOLAB">qaho<pc> –</pc>
                     <lb n="21"/>lab</rs> ta x que leh.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="32">
-                    <!-- <p xml:id="p32"> -->
+                    
                     <lb n="22"/>Xeoc chicut pa<rs ana="XUXULIM_JA">teuh ha</rs> ma<pc> –</pc>
                     <lb n="23"/>ui ahilan teu ꜩaꜩ chi zacbocom
                     <lb n="24"/>chupan ha rochoch teu huzu
@@ -2740,10 +2737,10 @@
                     <lb n="35"/>balba</rs> xquimaihah chic qui<pc> –</pc>
                     <lb n="36"/>banoh <rs ana="KA'IB_K'AJOLAB">qaholab</rs> <rs ana="XBALAMKE">xba<pc> –</pc>
                     <lb n="37"/>lan que</rs>
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="33">
-                    <!-- <p xml:id="p33"> -->
+                    
                     <lb n="38" rend="indent" />Cate xeoc chicut <rs ana="BALAM_JA">pabala
                     <lb n="39"/>mi ha</rs> ꜩaꜩ chibalam balam
                     <lb n="40"/>rochoch maui cohitio qo ivech
@@ -2761,10 +2758,10 @@
                     <lb n="4"/>naquipa quichi e vinaquil apa
                     <lb n="5"/>qui xepe vi xeqha ri  co<pc> –</pc>
                     <lb n="6"/>nohel
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="34">
-                    <!-- <p> -->
+                    
                     <lb n="7"/>Cate chic xeoc chupam <rs ana="JA_CHI_Q'AQ'">ꜫaꜫ
                     <lb n="8"/>hun ha</rs> chiꜫaꜫ, xa vtu que l ꜫaꜫ v
                     <lb n="9"/>pam maui xecatic rumal, xa
@@ -2774,10 +2771,10 @@
                     <lb n="13"/>camic chupan ri, que icou vi ma<pc> –</pc>
                     <lb n="14"/>ui que he xavi
                     <lb n="15"/>cazach quiqux rumal.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="35">
-                    <!-- <p xml:id="p35"> -->
+                    
                     <lb n="16"/>Xecoh chic chupan <rs ana="SOTZ'I_JA">zoꜩin ha</rs>
                     <lb n="17"/>vtu que l zoꜩ chupam chiha
                     <lb n="18"/>hun ha chi camazoꜩ nimac chi<pc> –</pc>
@@ -2877,10 +2874,10 @@
                     <lb n="13"/>pixabaxic chacab cate cut ta
                     <lb n="14"/>xzaquiric xavi xare vꜩqui<pc> –</pc>
                     <lb n="15"/>vach qui cabichal.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="36">
-                    <!-- <p xml:id="p36"> -->
+                    
                     <lb n="16" rend="indent" />xcah chicu quichaah colan
                     <lb n="17"/>chicu vholom <rs ana="JUNAJPU">hun ahpu</rs> chuvi
                     <lb n="18"/>hom. mi xcachacoyan, mixibano
@@ -2932,10 +2929,10 @@
                     <lb n="13"/>nima caxcol xecohevi ma<pc> –</pc>
                     <lb n="14"/>ui are xecam vi ri ronohel
                     <lb n="15"/>xban chique.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="37">
-                    <!-- <p xml:id="p37"> -->
+                    
                     <lb n="16" rend="indent" /><hi rend="large">A</hi>Are cut vae quinabal qui<pc> –</pc>
                     <lb n="17"/>camic <rs ana="JUNAJPU">hun ahpu</rs> <rs ana="XBALAMKE">xbalanque</rs> are
                     <lb n="18"/>va qui nabal qui camic xchica
@@ -3026,10 +3023,10 @@
                     <lb n="4"/>chuxe a chaom <rs ana="KA'IB_K'AJOLAB">qaholab</rs> xe
                     <lb n="5"/>vxic xavi xere qui vach xuxic
                     <lb n="6"/>xecutun chicut.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="38">
-                    <!-- <p xml:id="p38"> -->
+                    
                     <lb n="7" rend="indent" />Chi robix cut xecutun chix xe
                     <lb n="8"/>il chi ya rumal vinac e caib que
                     <lb n="9"/>heri xavinac car xevachinic
@@ -3055,10 +3052,10 @@
                     <lb n="29"/>quibano ronohel xquiban chic
                     <lb n="30"/>v xenaahic chic chacbal quech
                     <lb n="31"/><rs ana="XIBALBA">xibalba</rs> cumal.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="39">
-                    <!-- <p xml:id="p39"> -->
+                    
                     <lb n="32" rend="indent" />Cate chi puch roponic chic v
                     <lb n="33"/>ꜩihel quixahoh chi xiquin aha<pc> –</pc>
                     <lb n="34"/>uab <rs ana="JUN_KAME">huncame</rs>, <rs ana="WUQUB_KAME">vvcub came</rs> xch<pc> –</pc>
@@ -3095,10 +3092,10 @@
                     <lb n="17"/>mul xchihic xa chimachcay
                     <lb n="18"/>zamahel chiquivach camol que
                     <lb n="19"/>ta xebe cut ruq ahau.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="40">
-                    <!-- <p xml:id="p40"> -->
+                    
                     <lb n="20" rend="indent" />Xeopon puch cuq ahauab
                     <lb n="21"/>Quemocho chic chiqui xule la
                     <lb n="22"/>qui vach xeoponic xqui que<pc> –</pc>
@@ -3185,10 +3182,10 @@
                     <lb n="4"/>are quebanovic caquicot quiqux
                     <lb n="5"/><rs ana="JUN_KAME">huncame</rs> <rs ana="WUQUB_KAME">vvcub came</rs> queheri
                     <lb n="6"/>are quexahovic caquinao.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="41">
-                    <!-- <p xml:id="p41"> -->
+                    
                     <lb n="7" rend="indent" />Cate puch vrainic vmalinic
                     <lb n="8"/>pu quiqux ahauab chire qui
                     <lb n="9"/>xahoh <rs ana="JUNAJPU">xhun ahpu</rs> <rs ana="XBALAMKE">xbalanque</rs>
@@ -3238,10 +3235,10 @@
                     <lb n="2"/>bano. cate puch ta xquibÿh
                     <lb n="3"/>qui bi, xquicobizah quib chi<pc> –</pc>
                     <lb n="4"/>qui vach conohel <rs ana="XIBALBA">xibalba</rs>.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="42">
-                    <!-- <p xml:id="p42"> -->
+                    
                     <lb n="5" rend="indent" />Chitaa cabi xchicabÿh. xch<pc> –</pc>
                     <lb n="6"/>icabÿh naipuch vbi cacahau
                     <lb n="7"/>chive ohva, oh <rs ana="JUNAJPU">xhun ahpu</rs>
@@ -3325,10 +3322,10 @@
                     <lb n="37"/>chila chi <rs ana="XIBALBA">xibalba</rs>. xqhau chic qui
                     <lb n="38"/>cahau chiquetax xquichac <rs ana="XIBALBA">xi<pc> –</pc>
                     <lb n="39"/>balba</rs>.  <note resp="editor">somehow left out of flat, added by me </note>
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="43">
-                    <!-- <p xml:id="p43"> -->
+                    
                     <lb n="40" rend="indent"/>Vacute vviquic chic qui ca<pc> –</pc>
                     <lb n="41"/>hau cumal are xquivic ri <rs ana="WUQUB_JUNAJPU">vvcub
                     <lb n="42"/>hunahpu</rs> chila xbe quivica vi chi
@@ -3365,10 +3362,10 @@
                     <lb n="22"/>much qaholab</rs> xecam rumal
                     <lb n="23"/><rs ana="SIPAKNA">zipacna</rs> are cut cachbil xu<pc> –</pc>
                     <lb n="24"/>xic e vchumilal cah xevxic.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="44">
-                    <!-- <p xml:id="p44"> -->
+                    
                     <lb n="25" rend="indent"/><hi rend="large">V</hi>ae cut vtiqueric ta xnaohix
                     <lb n="26"/>vinac ta xꜩucux puch ri choc vtio<pc> –</pc>
                     <lb n="27"/>hilvinac xeqha cut ri <rs ana="ALOM">alom</rs> <rs ana="K'AJOLOM">qa<pc> –</pc>
@@ -3387,16 +3384,16 @@
                     <lb n="40"/>vtiohil vinac xazcaquin chic ma
                     <lb n="41"/>ui cauachin quih ic chumil pa
                     <lb n="42"/>qui vi e <rs ana="TZ'AQOL">ꜩacol</rs> <rs ana="BITOL">bitol</rs>.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="45">
-                    <!-- <p xml:id="p45"> -->
+                    
                     <lb n="43" rend="indent"/><hi rend="large">P</hi>an <rs ana="PAXIL">paxil</rs>, pan <rs ana="K'AYALA'">cayala</rs> vbi xpe
                     <lb n="44"/>vi eanahal zaquihal.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="46">
-                    <!-- <p xml:id="p46"> -->
+                    
                     <lb n="45" rend="indent"/><hi rend="large">A</hi>re cuquibi chicop va camolre
                     <lb n="46"/>cha. yac, vtiu, quel, hoh ecahib
                     <lb n="47"/>chi chicop xbÿn vꜩihel ꜫanahal
@@ -3432,20 +3429,20 @@
                     <lb n="28"/>can veab vinac ri e canabe ca<pc> –</pc>
                     <lb n="29"/>hau e cahib chivinac ꜩac xa
                     <lb n="30"/>echa oquinac quitiohil.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="47">
-                    <!-- <p xml:id="p47"> -->
+                    
                     <lb n="31" rend="indent"/><hi rend="large">V</hi>ae quibi naabe vinac xeꜩa<pc> –</pc>
                     <lb n="32"/>quic xebitic. are nabe vinac ri
                     <lb n="33"/><rs ana="BALAM_KI'TZE'">Balam qui ꜩe</rs>. vcab chicut <rs ana="BALAM_AQ'AB">Ba<pc> –</pc>
                     <lb n="34"/>lam acab</rs>. roxchi cut <rs ana="MAJUK'UTAJ">Mahucutah</rs>.
                     <lb n="35"/>vcah cut <rs ana="IK'I_BALAM">Iquibalam</rs>. are cu
                     <lb n="36"/>quibi ri canabe chuch cahau.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="48">
-                    <!-- <p xml:id="p48"> -->
+                    
                     <lb n="37" rend="indent"/>Xa ꜩac xa bit que vqhaxic
                     <lb n="38"/>mahabi quichuch mahabi qui<pc> –</pc>
                     <lb n="39"/>cahau xa vtuquel achih chica<pc> –</pc>
@@ -3481,10 +3478,10 @@
                     <lb n="18"/>tacah. quiꜩih vi chi eloeolah
                     <lb n="19"/>vinac ri <rs ana="BALAM_KI'TZE'">balam quiꜩe</rs>, <rs ana="BALAM_AQ'AB">Balam<pc> –</pc>
                     <lb n="20"/>acab</rs>, <rs ana="MAJUK'UTAJ">mahucutah</rs>, <rs ana="IK'I_BALAM">iquibalam</rs>.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="49">
-                    <!-- <p xml:id="p49"> -->
+                    
                     <lb n="21" rend="indent"/>Ta xeꜩonox cut rumal ri
                     <lb n="22"/><rs ana="TZ'AQOL">ahꜩac</rs> <rs ana="BITOL">ahbit</rs> huchalic iqohei
                     <lb n="23"/>quinao maqui xmucunic ma
@@ -3514,10 +3511,10 @@
                     <lb n="47"/>bit mixquetamah ronohel nim
                     <pb xml:id="xom-f34-s1"/>
                     <lb n="1"/>chutin queqha.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="50">
-                    <!-- <p xml:id="p50"> -->
+                    
                     <lb n="2" rend="indent"/>Quehe chicut vcamic chic
                     <lb n="3"/>qui naoh <rs ana="ALOM">alom</rs> <rs ana="K'AJOLOM">qaholom</rs> hucha
                     <lb n="4"/>chic chicaban chique xata nacah
@@ -3539,10 +3536,10 @@
                     <lb n="20"/><rs ana="K'AJOLOM">qaholom</rs>, <rs ana="XPIYAKOK">xpiyacoc</rs>, <rs ana="IXMUKANE">xmucane</rs> <rs ana="TZ'AQOL">ꜩa<pc> –</pc>
                     <lb n="21"/>col</rs> <rs ana="BITOL">bitol</rs> quevqhaxic ta xquiban
                     <lb n="22"/>cut vqoheic chic quiꜩac qui bit
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="51">
-                    <!-- <p xml:id="p51"> -->
+                    
                     <lb n="23" rend="indent"/>Xaca xvabax vbac qui vach
                     <lb n="24"/>rumal ri <rs ana="UK'U'X_KAJ">vqux cah</rs> xmoyic quehe<pc> –</pc>
                     <lb n="25"/>ri xuxlabix vvach lemo xmoyo<pc> –</pc>
@@ -3679,20 +3676,20 @@
                     <lb n="5"/>quiꜩe</rs>, <rs ana="BALAM_AQ'AB">balam acab</rs>, <rs ana="MAJUK'UTAJ">mahucutah</rs>
                     <lb n="6"/><rs ana="IK'I_BALAM">iqui balam</rs> xquitao vꜩihol hun
                     <lb n="7"/>tinamit xebevi
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="52">
-                    <!-- <p xml:id="p52"> -->
+                    
                     <lb n="8" rend="indent"/><hi rend="large">A</hi>recut vbi huyub va xebe vi
                     <lb n="9"/><rs ana="BALAM_KI'TZE'">Balam quiꜩe</rs>, <rs ana="BALAM_AQ'AB">Balam acab</rs> <rs ana="MAJUK'UTAJ">mahu
                     <lb n="10"/>cutah</rs>, <rs ana="IK'I_BALAM">iqui balam</rs> ruq <rs ana="TAMUB">tumub</rs>, <rs ana="ILOKAB">ilo<pc> –</pc>
                     <lb n="11"/>cab</rs>, <rs ana="TULÁN" type="toponym">tulan</rs><rs ana="SUYWA" type="toponym">zuiva</rs> vvcub pec, vv<pc> –</pc>
                     <lb n="12"/>cubzivan vbi tinamit xeopon vi
                     <lb n="13"/>e camolre cabauil
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="53">
-                    <!-- <p xml:id="p53"> -->
+                    
                     <lb n="14" rend="indent"/>Xeopon cut chila <rs ana="TULÁN">tulan</rs> conoh<pc> –</pc>
                     <lb n="15"/>el maui ahilan chivinac xoponic
                     <lb n="16"/>ꜩaꜩcut chubinic cholon cut relic
@@ -3716,10 +3713,10 @@
                     <lb n="34"/>ui <rs ana="TOJIL">tohil</rs> vbi cabavil xucamo
                     <lb n="35"/>quimam quicahau ahauab xa
                     <lb n="36"/>ui quetaam va camic
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="54">
-                    <!-- <p xml:id="p54"> -->
+                    
                     <lb n="37" rend="indent"/>Quehecut vbinaam vi ox<pc> –</pc>
                     <lb n="38"/>ib chiquiche xma xuꜩocopih
                     <lb n="39"/>virib rumal xa hunam vbi ca<pc> –</pc>
@@ -3769,10 +3766,10 @@
                     <lb n="34"/>hil arecut queꜫaꜫal ria
                     <lb n="35"/>mac quequicotic rumal qui
                     <lb n="36"/>ꜫaꜫ
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="55">
-                    <!-- <p xml:id="p55"> -->
+                    
                     <lb n="37" rend="indent" />Catepuch ta xticaric nima hab
                     <lb n="38"/>are catilo vꜫaꜫ amac ꜩaꜩ cut
                     <lb n="39"/>chi zacboch xachic pa qui vi ro
@@ -3844,10 +3841,10 @@
                     <lb n="9"/><rs ana="IK'I_BALAM">iqui balam</rs> nim vcatat qui qux
                     <lb n="10"/>chiquimah quichi chiqui mah qui
                     <lb n="11"/>vach
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="56">
-                    <!-- <p xml:id="p56"> -->
+                    
                     <lb n="12"/>Cate puch culic chic e eloeom
                     <lb n="13"/>chiquivach <rs ana="BALAM_KI'TZE'">balam quiꜩe</rs>, <rs ana="BALAM_AQ'AB">balam
                     <lb n="14"/>aeab</rs>, <rs ana="MAJUK'UTAJ">mahucutah</rs> <rs ana="IK'I_BALAM">iqui balam</rs>
@@ -3957,10 +3954,10 @@
                     <lb n="21"/>xepetic chila relebal quih chi<pc> –</pc>
                     <lb n="22"/>qui hunam vach xeicou vla
                     <lb n="23"/>chila <rs ana="NIM_XO'L">nim xol</rs> cabixic vacamic
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="57">
-                    <!-- <p xml:id="p57"> -->
+                    
                     <lb n="24"/>Taxevl puch chiri chuvi hun
                     <lb n="25"/>huyub chiri xquicuch vi quib
                     <lb n="26"/>conohel <rs ana="AJAW_K'ICHE'">queche vinac</rs> ruq a
@@ -3976,10 +3973,10 @@
                     <lb n="36"/>xic maui zachel oxib chi quiche
                     <lb n="37"/>xahunam caꜩih xeqhacut
                     <lb n="38"/>ta xcoh quibi
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="58">
-                    <!-- <p> -->
+                    
                     <lb n="39"/>Ta xbinaah chicuri <rs ana="KAQCHIKELEB">ꜫaꜫche<pc> –</pc>
                     <lb n="40"/>queleb</rs>. <rs ana="KAQCHIKELEB">ꜫaꜫchequeleb</rs> vbi xuxic
                     <lb n="41"/>ruc chic <rs ana="RABINALEB">rabinaleb</rs> are chicu
@@ -4026,10 +4023,10 @@
                     <lb n="34"/>qui biz taxe qoheic chuvi huyub
                     <lb n="35"/><rs ana="CHI_PIXAB">chipixab</rs> vbi vacamic xqha
                     <lb n="36"/>chi cut qui cabauil chiri.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="59">
-                    <!-- <p xml:id="p59"> -->
+                    
                     <lb n="37"/>Ta xqha cut ruq <rs ana="TOJIL">tohil</rs> <rs ana="AWILIX">au<pc> –</pc>
                     <lb n="38"/>lix</rs> <rs ana="JAQAWITZ">hacaviꜩ</rs> chiquech ri <rs ana="BALAM_KI'TZE'">Ba<pc> –</pc>
                     <lb n="39"/>lam quiꜩe</rs>, <rs ana="BALAM_AQ'AB">balam acab</rs>, <rs ana="MAJUK'UTAJ">mahu<pc> –</pc>
@@ -4139,16 +4136,16 @@
                     <lb n="47"/>chi cabÿh chic vzaquiric vva<pc> –</pc>
                     <pb xml:id="xom-f40-s1"/>
                     <lb n="1"/>chinic puch quih, ic, qhumil
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="60">
-                    <!-- <p xml:id="p60"> -->
+                    
                     <lb n="2" rend="indent"/>Vae cute vzaquiric vvachi<pc> –</pc>
                     <lb n="3"/>nic puch quih, ic, qhumil.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="61">
-                    <!-- <p xml:id="p61"> -->
+                    
                     <lb n="4" rend="indent"/><hi rend="large">N</hi>im cut xe quicotic <rs ana="BALAM_KI'TZE'">balam
                     <lb n="5"/>quiꜩe</rs>, <rs ana="BALAM_AQ'AB">balam acab</rs>, <rs ana="MAJUK'UTAJ">mahucutah</rs>,
                     <lb n="6"/><rs ana="IK'I_BALAM">iqui balam</rs> ta xril ri icoquih. na
@@ -4295,10 +4292,10 @@
                     <lb n="3"/>qui qux chire ri <rs ana="TOJIL">tohil</rs><rs ana="AWILIX">aulix</rs> <rs ana="JAQAWITZ">ha<pc> –</pc>
                     <lb n="4"/>caviꜩ</rs> areqochic pa ec pa ꜩi<pc> –</pc>
                     <lb n="5"/>yac cumal.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="62">
-                    <!-- <p xml:id="p62"> -->
+                    
                     <lb n="6" rend="indent"/>Vacute quicatonic vxe chipu<pc> –</pc>
                     <lb n="7"/>ch cohbal rech <rs ana="TOJIL">tohil</rs> ta xebe
                     <lb n="8"/>cut chu vach <rs ana="TOJIL">tohil</rs> <rs ana="AWILIX">aulix</rs> xbequila x<pc> –</pc>
@@ -4421,17 +4418,17 @@
                     <lb n="29"/>zib</rs> vbi ruq quic choc chiquih
                     <lb n="30"/>qui hab rib riquic xuxic vyaon
                     <lb n="31"/><rs ana="TOJIL">tohil</rs> ruq <rs ana="AWILIX">aulix</rs> x <rs ana="JAQAWITZ">hacaviꜩ</rs>.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="63">
-                    <!-- <p xml:id="p63"> -->
+                    
                     <lb n="32" rend="indent"/><hi rend="large">V</hi>ae vticaric chic relecaxic vi<pc> –</pc>
                     <lb n="33"/>nac amac cumal <rs ana="BALAM_KI'TZE'">balam quiꜩe</rs>, <rs ana="BALAM_AQ'AB">ba
                     <lb n="34"/>lam acab</rs> <rs ana="MAJUK'UTAJ">mahucutah</rs> <rs ana="IK'I_BALAM">iqui balam</rs>.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="64">
-                    <!-- <p xml:id="p64"> -->
+                    
                     <lb n="35" rend="indent"/><hi rend="large">C</hi>ate puch vcamizaxic amac ri
                     <lb n="36"/>are xquicam ri xa hun chubinic
                     <lb n="37"/>xa caib chubinic maui calah ta chi<pc> –</pc>
@@ -4487,10 +4484,10 @@
                     <lb n="39"/>hucutah</rs> <rs ana="IK'I_BALAM">iqui balam</rs>. arecu va<pc> –</pc>
                     <lb n="40"/>vcamic vnaoh amac chire vca<pc> –</pc>
                     <lb n="41"/>mizaxic tah.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="65">
-                    <!-- <p xml:id="p65"> -->
+                    
                     <lb n="42" rend="indent"/><hi rend="large">N</hi>abe cut xrah qui naohih a<pc> –</pc>
                     <lb n="43"/>mac vchaquic <rs ana="TOJIL">tohil</rs> <rs ana="AWILIX">avlix</rs> <rs ana="JAQAWITZ">hacaviꜩ</rs>
                     <lb n="44"/>xeqha ronohel vi ahquixb ahcahb
@@ -4560,10 +4557,10 @@
                     <lb n="12" />xetac vbic chiya chi <rs ana="EL_BAÑO_DE_TOJIL">ratinibal
                     <lb n="13" />tohil aulix hacaviꜩ</rs>. are qui
                     <lb n="14" />naoh ronohel amac rÿ.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="66">
-                    <!-- <p xml:id="p66"> -->
+                    
                     <lb n="15" rend="indent" />Cate puch xebec xecauuxic qui<pc> –</pc>
                     <lb n="16" />bec chila <rs ana="EL_BAÑO_DE_TOJIL">chatin vi tohil</rs> quicari<pc> –</pc>
                     <lb n="17" />loon curi qui chahon ta xebec. que
@@ -4596,10 +4593,9 @@
                     <lb n="44" />xcah ri amac xehox ta ri <rs ana="IXTAJ_IXPUCH'">capo<pc> –</pc>
                     <lb n="45" />hib</rs> rumal qui naual <rs ana="TOJIL">tohil</rs> xe
                     <lb n="46" />qha curi <rs ana="TOJIL">tohil</rs> <rs ana="AWILIX">aulix</rs> <rs ana="JAQAWITZ">hacaviꜩ</rs>
-                    <!-- </p> -->f
                 </p>
                 <p n="67">
-                    <!-- <p> -->
+                    
                     <pb xml:id="xom-f44-s2"/>
                     <lb n="1"/>ta xeqhau chic chiquech ri xtah
                     <lb n="2"/>xpuch quibi re <rs ana="IXTAJ_IXPUCH'">e caib capohib</rs>
@@ -4615,10 +4611,10 @@
                     <lb n="12"/>capohib</rs> quechahonic chi ya vbic
                     <lb n="13"/>chique xevqhax cut <rs ana="BALAM_KI'TZE'">balam qui<pc> –</pc>
                     <lb n="14"/>ꜩe</rs>, <rs ana="BALAM_AQ'AB">balam acab</rs>, <rs ana="MAJUK'UTAJ">mahucutah</rs>.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="68">
-                    <!-- <p xml:id="p67"> -->
+                    
                     <lb n="15" rend="indent"/>Cate cut xezibanic coxichal na<pc> –</pc>
                     <lb n="16"/>be xꜩiban ri <rs ana="BALAM_KI'TZE'">balam quiꜩe</rs>. balam
                     <lb n="17"/>vvachibal xuxic xuꜩibah chu<pc> –</pc>
@@ -4711,10 +4707,10 @@
                     <lb n="8"/>quicamizaxic rumal amac ta x<pc> –</pc>
                     <lb n="9"/>quicuch quib conohel xepoponic
                     <lb n="10"/>xeta co quib conohel.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="69">
-                    <!-- <p xml:id="p68"> -->
+                    
                     <lb n="11" rend="indent"/><hi>V</hi>ae cute qui molouic quib co<pc> –</pc>
                     <lb n="12"/>nohel amac e cauutal chic chi
                     <lb n="13"/>chab chipocob conohel maui a
@@ -4818,10 +4814,10 @@
                     <lb n="15"/>are qo chuvi <rs ana="JAQAWITZ_JUYUB">huyub hacaviꜩ</rs> vbi
                     <lb n="16"/>e qo vi are cut coquibexic va xchi
                     <lb n="17"/>cabÿh chic
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="70">
-                    <!-- <p xml:id="p69"> -->
+                    
                     <lb n="18" rend="indent"/><hi>A</hi>re cut e qo chiri <rs ana="BALAM_KI'TZE'">balam quiꜩe</rs>
                     <lb n="19"/><rs ana="BALAM_AQ'AB">balam acab</rs> <rs ana="MAJUK'UTAJ">mahucutah</rs> <rs ana="IK'I_BALAM">iqui ba<pc> –</pc>
                     <lb n="20"/>lam</rs> xa hun e qo vi chuvi <rs ana="JAQAWITZ_JUYUB">huyub</rs> ruq
@@ -4897,10 +4893,10 @@
                     <lb n="42"/>chicabÿh chic qui camic <rs ana="BALAM_KI'TZE'">balam
                     <lb n="43"/>quiꜩe</rs> <rs ana="BALAM_AQ'AB">balam acab</rs>, <rs ana="MAKUJUTAJ">mahucutah</rs>
                     <lb n="44"/><rs ana="IK'I_BALAM">iqui balam</rs> qui bi.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="71">
-                    <!-- <p xml:id="p70"> -->
+                    
                     <lb n="45" rend="indent"/><hi>X</hi>quina cut qui camic qui zachic
                     <lb n="46"/>ta xepixabic chirech qui qahol ma
                     <lb n="47"/>na eta iab mapu quehilovic que<pc> –</pc>
@@ -4990,10 +4986,10 @@
                     <lb n="35"/>relebalquih oher oc quevl
                     <lb n="36"/>varal taxecamic erih chic e
                     <lb n="37"/>ahquixb ahcahb quibinaam.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="72">
-                    <!-- <p xml:id="p71"> -->
+                    
                     <lb n="38" rend="indent" />Cate puch taxquiquxlaah qui<pc> –</pc>
                     <lb n="39"/>bÿc chila relebal quih are qui
                     <lb n="40"/>quxlaan ri vpixab qui cahau
@@ -5027,10 +5023,10 @@
                     <lb n="17"/>cama ri ahauarem. are cu v<pc> –</pc>
                     <lb n="18"/>biahau va rahaual ahrele<pc> –</pc>
                     <lb n="19"/>bal quih xeoponvi.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="73">
-                    <!-- <p xml:id="p72"> -->
+                    
                     <lb n="20" rend="indent" /><hi rend="large">T</hi>a xeopon cut chuvach ahau
                     <lb n="21"/><rs ana="NAKXIT">nacxit</rs> vbi nim ahau xahu
                     <lb n="22"/>catol ꜩih ꜩaꜩ rahauarem are
@@ -5050,10 +5046,10 @@
                     <lb n="36"/>vlari chaca <rs ana="PALOW">palo</rs> vꜩibal <rs ana="TULÁN">tulan</rs>
                     <lb n="37"/>vꜩibal xeqha chire qui oqui<pc> –</pc>
                     <lb n="38"/>nac chupan chupan quiꜩih.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="74">
-                    <!-- <p xml:id="p73"> -->
+                    
                     <lb n="39" rend="indent" />Cate puch ta xevlic chiri chu<pc> –</pc>
                     <lb n="40"/>ui quitinamit <rs ana="JAQAWITZ_JUYUB">hacaviꜩ</rs> vbi chi<pc> –</pc>
                     <lb n="41"/>ricut xecuch vi ronohel <rs ana="TAMUB">tam<pc> –</pc>
@@ -5120,10 +5116,10 @@
                     <lb n="2"/>quitinamit emamexel epu
                     <lb n="3"/>cahauixel va cu vbi tinamit
                     <lb n="4"/>e xevl vi
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="75">
-                    <!-- <p xml:id="p74"> -->
+                    
                     <lb n="5"/><rs ana="CHI_ISMACHI">Chiizmachi</rs> cut vbihuyub qui
                     <lb n="6"/>tinamit xeqohe vi chinaipuchxe
                     <lb n="7"/>amaquelab vi chiri cut xqui<pc> –</pc>
@@ -5240,10 +5236,10 @@
                     <lb n="14"/>ban chiri <rs ana="CHI_ISMACHI">chiizmachi</rs> taxqui ric
                     <lb n="15"/>chic taxquil puch hunchic tina<pc> –</pc>
                     <lb n="16"/>mit xcocotah chivi ri <rs ana="CHI_ISMACHI">chiizmachi</rs>.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="76">
-                    <!-- <p xml:id="p75"> -->
+                    
                     <lb n="17"/>Catepuch taxeyacatah chivl
                     <lb n="18"/>oc xevlchiri patinamit <rs ana="Q'UMARAQ_AJ">cumarca<pc> –</pc>
                     <lb n="19"/>ah</rs> vbi cumal quiche chuqha xic
@@ -5297,10 +5293,10 @@
                     <lb n="15"/><rs ana="SAQIK">chinamital</rs> huhun chiahauab chi
                     <lb n="16"/>cabÿh quibi riahauab chuhu<pc> –</pc>
                     <lb n="17"/>hunal huhun vnim ha.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="77">
-                    <!-- <p xml:id="p76"> -->
+                    
                     <lb n="18" rend="indent" /><hi rend="large">V</hi>ae cute quibi ahauab chu
                     <lb n="19"/>vach <rs ana="KAWEQ">caui quib</rs> are nabe ahau
                     <lb n="20"/>va, <rs ana="AJPOP">ahpop</rs> <rs ana="AJPOP_K'AMJA">ahpop camha</rs>, <rs ana="AJTOJIL">ah to<pc> –</pc>
@@ -5308,18 +5304,18 @@
                     <lb n="22"/>vec</rs>, <rs ana="POPOL_WINAQ_CHI_T'UY">popol vinac, chituy</rs> <rs ana="LOLMET_KEJNAY">lolmet,
                     <lb n="23"/>queh nay</rs>. <rs ana="POPOL_WINAQ_PA_JOM_TZALATZ'">popol vinac, pahom
                     <lb n="24"/>ꜩalaꜩ</rs>, vchuch cam ha.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="78">
-                    <!-- <p xml:id="p77"> -->
+                    
                     <lb n="25" rend="indent" /><hi rend="large">A</hi>re cut ahauab ri chuvach
                     <lb n="26"/><rs ana="KAWEQ">caviquib</rs> beleheb chi ahauab
                     <lb n="27"/>colehe vnimha chuhuhunal ca
                     <lb n="28"/>te chic chivachin v vach.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="79">
-                    <!-- <p xml:id="p78"> -->
+                    
                     <lb n="29" rend="indent" /><hi rend="large">A</hi>re chicu ahavab va chu
                     <lb n="30"/>vach <rs ana="NIJA'IB">nihaibab</rs> are nabe aha<pc> –</pc>
                     <lb n="31"/>u va <rs ana="AJAW_Q'ALEL">ahau ealel</rs>, <rs ana="AJAW_AJTZIK_WINAQ">ahau ahꜩic vi<pc> –</pc>
@@ -5329,29 +5325,29 @@
                     <lb n="35"/>zaclatol</rs>, <rs ana="NIMA_LOLMET_YE'OLTUX">nima lolmet yeoltux</rs>.
                     <lb n="36"/>beleheb cut chi ahauab chuva<pc> –</pc>
                     <lb n="37"/>ch <rs ana="NIJA'IB">nihaibab</rs>
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="80">
-                    <!-- <p xml:id="p79"> -->
+                    
                     <lb n="38" rend="indent" /><hi rend="large">A</hi>re chicut ahau quiche va
                     <lb n="39"/>vae quibi ahauab. ahꜩic vinac
                     <lb n="40"/><rs ana="AJAW_LOLMET">ahau lolmet</rs>, <rs ana="AJAW_NIM_CH'OKOJ">ahau nim chocoh</rs>
                     <lb n="41"/>ahau, <rs ana="AJAW_JAQAWITZ">ahau hacaviꜩ</rs>. cahib a<pc> –</pc>
                     <lb n="42"/>hauab chuvach <rs ana="AJAW_K'ICHE'">ahau quiche</rs><pc> –</pc>
                     <lb n="43"/>eb colehe vnim ha.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="81">
-                    <!-- <p xml:id="p80"> -->
+                    
                     <lb n="44"/>Ca<gap reason="deletion" unit="character" instant="false"/>ib chinamit chi na ipuch
                     <lb n="45"/>ca quiquib au<add place="above" instant="false" status="unremarkable">ha</add>ab <rs ana="TZUTUJA">ꜩutuha</rs>
                     <unclear reason="illegible" instant="false">y</unclear> <rs ana="Q'ALEL_SAQIK">ealel
                     <lb n="46"/>'zaquic</rs> xahun chi nim ha ecaib
                     <lb n="47"/>chiahauab.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="82">
-                    <!-- <p xml:id="p81"> -->
+                    
                     <pb xml:id="xom-f51-s2"/>
                     <note  place="margin-left" type="pagination" anchored="true">
                     <num rend="large"><hi rend="handwriting;color:pencil">51</hi></num>
@@ -5428,10 +5424,10 @@
                     <lb n="22"/><rs ana="ISTAYUL_KQSEIS">ztayul</rs> xaqui ahauarem xu<pc> –</pc>
                     <lb n="23"/>bano role ahau xuxic xaui xe
                     <lb n="24"/>qaholanic hutac le chiahauab.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="83">
-                    <!-- <p xml:id="p82"> -->
+                    
                     <lb n="25" rend="indent"/>Va chicute quibÿ chic vvac
                     <lb n="26"/>le ahau e caib chinimac aha<pc> –</pc>
                     <lb n="27"/>uab <rs ana="K'IKAB_KQSIETE">eꜫaꜫ quicab</rs> vbi hun ahau
@@ -5483,10 +5479,10 @@
                     <lb n="22"/>uab conohel taxbec catei rih
                     <lb n="23"/>zivan rih tinamit xcahinac ocv
                     <lb n="24"/>tinamit ronohel amac.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="84">
-                    <!-- <p xml:id="p83"> -->
+                    
                     <lb n="25" rend="indent"/>Catecut ta relic varanel ilol
                     <lb n="26"/>ahlabal ta xquiba cut vvachinel
                     <lb n="27"/>chinamit lacabei huyub ve chi<pc> –</pc>
@@ -5569,17 +5565,17 @@
                     <lb n="5"/>chap vi vnabe al qahol. ta xetac
                     <lb n="6"/>cut runohel qo pa huhun chihu<pc> –</pc>
                     <lb n="7"/>yub xa hun xecuchvi.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="85">
-                    <!-- <p xml:id="p84"> -->
+                    
                     <lb n="8" rend="indent"/><rs ana="XE_BALAX">Xebalax</rs>, <rs ana="XE_KAMAQ">xecamac</rs> vbi huyub
                     <lb n="9"/>xechap vi taxoc qui calem chiri
                     <lb n="10"/><rs ana="CHULIMAL">chulimal</rs> xbanvi
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="86">
-                    <!-- <p xml:id="p85"> -->
+                    
                     <lb n="11" rend="indent"/>Va cute qui cobic qui chapic
                     <lb n="12"/>quetaxic puch huvinac ealel hu
                     <lb n="13"/>vinac ahpop xchapic rumal ah<pc> –</pc>
@@ -5603,10 +5599,10 @@
                     <lb n="31"/>quehe relic ri ta xeelic chirih <rs ana="AJPOP">ah
                     <lb n="32"/>pop</rs> ahpop camha chirih puchca<pc> –</pc>
                     <lb n="33"/>lel <rs ana="AJTZIK_WINAQ">ahꜩicvinac</rs> xelvi
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="87">
-                    <!-- <p xml:id="p86"> -->
+                    
                     <lb n="34" rend="indent"/><hi rend="large">A</hi>recut xchicabÿhchic vbiro
                     <lb n="35"/>choch cabauil xavi xere xubi<pc> –</pc>
                     <lb n="36"/>naah rochoch ri vbi cabauil ni<pc> –</pc>
@@ -5666,10 +5662,10 @@
                     <lb n="42"/>chicah vacute quiꜩonobal chu<pc> –</pc>
                     <lb n="43"/>vach qui cabauil taqueꜩononic
                     <lb n="44"/>are cut roqueh qui quxva
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="88">
-                    <!-- <p xml:id="p87"> -->
+                    
                     <lb n="45" rend="indent"/><hi rend="large">A</hi>carroc atoob vquih, <rs ana="HURACAN">athu<pc> –</pc>
                     <lb n="46"/>racan</rs>, <rs ana="UK'U'X_KAJ_UK'U'X_ULEW">at vquxcah vleu</rs>, at ya<pc> –</pc>
                     <lb n="47"/>olrech eanal raxal atpuyaol
@@ -5749,10 +5745,10 @@
                     <lb n="22"/>are chicut xchicacholo vleel
                     <lb n="23"/>ahavab ruq quibi conohel aha<pc> –</pc>
                     <lb n="24"/>uab xchicabÿh chic.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="89">
-                    <!-- <p xml:id="p88"> -->
+                    
                     <lb n="25" rend="indent"/><hi rend="large">V</hi>ae cute vleel, vtazel aha<pc> –</pc>
                     <lb n="26"/>uarem chi ronohel quizaquiri<pc> –</pc>
                     <lb n="27"/>hem <rs ana="BALAM_KI'TZE'">balam quiꜩe</rs>, <rs ana="BALAM_AQ'AB">balam acab</rs>
@@ -5769,72 +5765,72 @@
                     <lb n="38"/>chuhuhunal ahauabva.
                     <lb n="39"/>cate xchivachin vvach huhun chuhu<pc> –</pc>
                     <lb n="40"/>hunal ahauab quiche
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="90">
-                    <!-- <p> -->
+                    
                     <lb n="41" rend="indent"/><rs ana="BALAM_KI'TZE'"><hi rend="large">B</hi>alam quiꜩe</rs> vxe nabal <rs ana="KAWEQ">cavi
                     <lb n="42" rend="hanging"/>quib</rs>
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="43"/><rs ana="K'OQAWIB_KQDOS"><hi rend="large">Cocauib</hi></rs> vcale chic <rs ana="BALAM_KI'TZE'">balam quiꜩe</rs>
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="44"/><rs ana="BALAM_K'ONACHE'_KQTRES"><hi rend="large">B</hi>alam conache</rs> xtiquiban ahpopol
                     <lb n="45" rend="hanging"/>roxle curi
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="46"/><rs ana="K'OTUJA_KQCUATRO"><hi rend="large">C</hi>otuha</rs> <rs ana="ISTAYUL_KQCUATRO">ztayub</rs> vcahle
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="47"/><rs ana="Q'UKUMATZ_KQCINCO"><hi rend="large">C</hi>ucumaꜩ</rs> <rs ana="K'OTUJA_KQCINCO">cotuha</rs> vxe naval ahau
                     <pb xml:id="xom-f55-s2"/>
                     <note place="margin-left" type="pagination" anchored="true">
                     <num rend="large"><hi rend="handwriting;color:pencil">55</hi></num>
                     </note>
                     <lb n="1" rend="hanging" />role xqohe vi
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="2"/><rs ana="TEPEPUL_KQSEIS"><hi rend="large">T</hi>epepul</rs> <rs ana="ISTAYUL_KQSEIS">ztayul</rs> chic vvac taz.
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="3"/><rs ana="K'IKAB_KQSIETE"><hi rend="large">Q</hi>uicab</rs> <rs ana="KAWISIMAJ_KQSIETE">cauizimah</rs> vvc hal aha
                     <lb n="4" rend="hanging" />uarem naval chivi
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="5"/><rs ana="TEPEPUL_KQOCHO"><hi rend="large">T</hi>epepul</rs> <rs ana="ISTAYUL_KQOCHO">xtayub</rs> v vahxac le
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="6"/><rs ana="TEKUM_KQNUEVE"><hi rend="large">T</hi>ecum</rs> <rs ana="TEPEPUL_KQNUEVE">tepepul</rs> vbeleh le
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="7"/><rs ana="WAJXAQIB_K'AM_KQDIEZ"><hi rend="large">V</hi>ahxaqui caam</rs> <rs ana="K'IKAB_KQDIEZ">quicab</rs> cut vla
                     <lb n="8" rend="hanging" />hule ahavab
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="9"/><rs ana="WUQUB_NO'J_KQONCE"><hi rend="large">V</hi>ucub noh</rs> <rs ana="KUWATEPECH_KQONCE">cauatepech</rs> chic vhu<pc> –</pc>
                     <lb n="10"/>lahu taz ahauab
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="11"/><rs ana="OXIB_KEJ_KQDOCE"><hi rend="large">O</hi>xib quieh</rs><rs ana="BELEJEB_TZI_KQDOCE">beleheb ꜩi</rs> vcabla<pc> –</pc>
                     <lb n="12" rend="hanging" />hule ahauab. arecut que aha
                     <lb n="13" rend="hanging" />uaric taxul <rs ana="DONADIU">Donadiu</rs> xehiꜩa<pc> –</pc>
                     <lb n="14" rend="hanging" />xic rumal castillan vinac
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="15"/><rs ana="TEKUM_TRECE"><hi rend="large">T</hi>ecum</rs> <rs ana="TEPEPUL_TRECE">tepepul</rs> xepatanihic chu<pc> –</pc>
                     <lb n="16" rend="hanging" />uach castillan vinac are xe
                     <lb n="17" rend="hanging" />qaholan eanoc roxlahu lea
                     <lb n="18" rend="hanging" />hauab
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="19"/><rs ana="DON_JUAN_DE_ROJAS_KQCATORCE"><hi rend="large">D</hi>on Ju<hi rend="superscript">o.</hi> de Rojas</rs> <rs ana="DON_JUAN_CORTÉS_KQCATORCE">Don Ju<hi rend="superscript">o.</hi> cortes</rs>
                     <lb n="20"/>cablahu le ahauab eqahola<pc> –</pc>
                     <lb n="21"/>xel rumal <rs ana="TEKUM_TRECE">tecum</rs> <rs ana="TEPEPUL_TRECE">tepepul</rs>
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="91">
-                    <!-- <p xml:id="p89"> -->
+                    
                     <lb n="22"/><hi rend="large">A</hi>recut vleel vtazel ahauarem
                     <lb n="23"/>ri ahau <rs ana="AJPOP">ahpop</rs> <rs ana="AJPOP_K'AMJA">ahpop camba</rs> chu<pc> –</pc>
                     <lb n="24"/>vach <rs ana="KAWEQ">caviquib</rs> quiche are chi xchi<pc> –</pc>
@@ -5844,153 +5840,153 @@
                     <lb n="28"/>naam ri beleheb <rs ana="SAQIK">chinamit</rs> <rs ana="KAWEQ">chica<pc> –</pc>
                     <lb n="29"/>uiquib</rs> beleheb vnimha va tac
                     <lb n="30"/>vbi e rahaual huhun chi nimha.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="92">
-                    <!-- <p> -->
+                    
                     <lb n="31"/><hi rend="large">A</hi>hau ahpop hun vnimha cuhavbi
                     <lb n="32" rend="hanging" />nimha
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="33"/><hi rend="large">A</hi>hau ahpopcamha ꜩiquinahavbi
                     <lb n="34" rend="hanging" />vnimha
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="35"/><rs ana="NIM_CH'OKOJ_KAWEQ"><hi rend="large">N</hi>im chocoh cavec</rs> hun vnimha ah<pc> –</pc>
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="36"/><hi rend="large">A</hi>hau ahtohil hun vnimha.
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="37"/><hi rend="large">A</hi>hau ah cucumaꜩ hun vnimha
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="38"/><hi rend="large">P</hi>opolvinac chitui hun vnimha
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="39"/><rs ana="LOLMET_KEJNAY"><hi rend="large">L</hi>olmet queh nai</rs> hun vnimha
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="40"/><rs ana="POPOL_WINAQ_PA_JOM_TZALATZ"><hi rend="large">P</hi>opolvinac pahom ꜩalaꜩ</rs> xcuxe<pc> –</pc>
                     <lb n="41" rend="hanging" />ba hun vnimha.
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="42"/><rs ana="YAKI_TEPEW"><hi rend="large">T</hi>epeu iaqui</rs> hun vnimha
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="93">
-                    <!-- <p xml:id="p90"> -->
+                    
                     <lb n="43" rend="indent" /><hi rend="large">A</hi>re curi bele heb <rs ana="SAQIK">chinamit</rs> chi<pc> –</pc>
                     <lb n="44"/>cavi quib ꜩaꜩ ral vqahol ahilatal
                     <lb n="45"/>chirih beleheb chinim ha
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="94">
-                    <!-- <p xml:id="p91"> -->
+                    
                     <lb n="46"/><hi rend="large">V</hi>acute rech <rs ana="NIJA'IB">nihaibab</rs> beleheb
                     <lb n="47"/>chivi chinimha are nabe xchica<pc> –</pc>
                     <pb xml:id="xom-f56-s1"/>
                     <lb n="1"/>bÿh vleabal rib ahauarem xa
                     <lb n="2"/>hun vxe x<add place="above" instant="false" status="unremarkable">ch</add>ticar  chuvach vxe
                     <lb n="3"/>quih vxe zac chivinac
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="95">
-                    <!-- <p> -->
+                    
                     <lb n="4"/><rs ana="BALAM_AQ'AB "><hi rend="large">B</hi>alam acab</rs> nabe mamaxel ca
                     <lb n="5" rend="hanging"/>hauixel.
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="6"/><rs ana="K'O'AKUL_NJDOS"><hi rend="large">C</hi>oacul</rs><rs ana="K'O'AKUTEK_NJDOS">coacutac</rs> vcale
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="7"/><rs ana="K'OCHAJUJ_NJTRES"><hi rend="large">C</hi>ochahuh</rs><rs ana="K'OTZ'IBAJA_NJTRES">coꜩibaha</rs> roxle
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="8"/><rs ana="BELEJEB_KEJ_NJCUATRO"><hi rend="large">B</hi>eleheb quih</rs> vcah le chic
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="9"/><rs ana="K'OTUJA_NJCINCO"><hi rend="large">C</hi>otuha</rs> ro le ahau
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="10"/><rs ana="BATZ'A_NJSEIS"><hi rend="large">B</hi>aꜩa</rs> chicut v vacle chic
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="11"/><rs ana="ISTAYUL_NJSIETE"><hi rend="large">Z</hi>tayul</rs> chicut v vcle ahau
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="12"/><rs ana="K'OTUJA_NJOCHO"><hi rend="large">C</hi>otuha chivi</rs> v vahxac taz aha
                     <lb n="13" rend="indent"/>uarem.
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="14"/><rs ana="BELEJEB_KEJ_NUEVE"><hi rend="large">B</hi>eleheb quih</rs> vbeleh taz
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="15"/><rs ana="KE'EMA_NJDIEZ"><hi rend="large">Q</hi>uema chuqhax</rs> chic vlahu le
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="16"/><rs ana="AJAW_K'OTUJA_NJONCE"><hi rend="large">A</hi>hau cotuha</rs> vhulahu le.
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="17"/><rs ana="DON_CRISTÓBAL_NJONCE"><hi rend="large">D</hi>on christoual chuchaxic</rs> xa
                     <lb n="18" rend="indent"/>hauaric chuvach caxtilan vi<pc> –</pc>
                     <lb n="19" rend="indent"/>nac
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="20"/><rs ana="DON_PEDRO_DE_ROBLES_NJDOCE"><hi rend="large">z<choice><abbr>D</abbr><expan instant="false">Don</expan></choice></hi>. Pedro de robles</rs> <rs ana="AJAQ_Q'ALEL_NJDOCE">ahau ꜫalel</rs>
                     <lb n="21"/>vacamic.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="96">
-                    <!-- <p xml:id="p92"> -->
+                    
                     <lb n="22" rend="indent"/><hi rend="large">A</hi>re curi chi ronobel ahavab
                     <lb n="22.1"/>elenac chirih ri <rs ana="AJAW_Q'ALEL">ahau ꜫalel</rs> are
                     <lb n="22.2"/>chic xchicabÿh rahaual huhun
                     <lb n="22.3"/>chinim ha.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="97">
-                    <!-- <p> -->
+                    
                     <lb n="23"/><note place="margin-left" anchored="true"><hi rend="handwriting;color:pencil"><num>1</num></hi></note><rs ana="AJAW_Q'ALEL"><hi rend="large">A</hi>hau ꜫalel</rs> vnabe ahau chuva<pc> –</pc>
                     <lb n="24" rend="indent"/>ch <rs ana="NIJA'IB">nihaibab</rs> hun vnim ha.
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="25"/><note place="margin-left" anchored="true"><hi rend="handwriting;color:pencil"><num>2</num></hi></note><rs ana="AJAW_AJTZIK_WINAQ"><hi rend="large">A</hi>hau ah ꜩic vinac</rs> hun vnim ha
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="26"/><note place="margin-left" anchored="true"><hi rend="handwriting;color:pencil"><num>3</num></hi></note><rs ana="Q'ALEL_K'AMJA"><hi rend="large">A</hi>hau ꜫalel camha</rs> hun vnim ha.
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="27"/><note place="margin-left" anchored="true"><hi rend="handwriting;color:pencil"><num>4</num></hi></note><rs ana="NIMA_K'AMJA"><hi rend="large">N</hi>ima camha</rs> hun vnim ha.
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="28"/><note place="margin-left" anchored="true"><hi rend="handwriting;color:pencil"><num>5</num></hi></note><rs ana="UCHUCH_K'AMJA"><hi rend="large">V</hi>chuch camha</rs> hun vnim ha.
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="29"/><note place="margin-left" anchored="true"><hi rend="handwriting;color:pencil"><num>6</num></hi></note><rs ana="NIMA_K'AMJA"><hi rend="large">N</hi>ima camha</rs> hun vnim ha.
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="30"/><note place="margin-left" anchored="true"><hi rend="handwriting;color:pencil"><num>7</num></hi></note><rs ana="NIM_CH'OKOJ_NIJA'IB"><hi rend="large">N</hi>im chocoh nihaib</rs> hun vnim ha.
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="31"/><note place="margin-left" anchored="true"><hi rend="handwriting;color:pencil"><num>8</num></hi></note><rs ana="AJAW_AWILIX"><hi rend="large">A</hi>hau auilix</rs> hun vnim ha.
-                    <!-- </p> -->
-                    <!-- <p> -->
+                    
+                    
                     <lb n="32"/><note place="margin-left" anchored="true"><hi rend="handwriting;color:pencil"><num>9</num></hi></note><rs ana="YAKOLATAM"><hi rend="large">Y</hi>acolatam</rs> hun vnim ha.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="98">
-                    <!-- <p xml:id="p93"> -->
+                    
                     <lb n="33" rend="indent"/><hi rend="large">A</hi>recut nim ha ri chuvach <rs ana="NIJA'IB">ni<pc> –</pc>
                     <lb n="34"/>haibab</rs> are vbinaam vi beleheb
                     <lb n="35"/>chinamit chi <rs ana="NIJA'IB">nihaibab</rs> chuqha<pc> –</pc>
                     <lb n="36"/>xic. quiia tac cut vchinamital hu<pc> –</pc>
                     <lb n="37"/>hun chique ahauab are vnabe
                     <lb n="38"/>ri mi xcabÿ quibi.
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="99">
-                    <!-- <p xml:id="p94"> -->
+                    
                     <lb n="39" rend="indent"/><hi rend="large">A</hi>re chicut rech <rs ana="AJAW_K'ICHE'">ahau qui che</rs>
                     <lb n="40"/>va vmam vcahau
                     <lb n="41"/><rs ana="MAJUK'UTAJ">Mahucutah</rs> nabe vinac<del instant="false" status="unremarkable"><hi rend="overstrike">cu</hi></del>
@@ -6004,10 +6000,10 @@
                     <lb n="3"/><rs ana="K'OKAMEL_AKSIETE">Cocamel</rs>
                     <lb n="4"/><rs ana="K'OYABAKOJ_AKOCHO">Coyabacoh</rs>
                     <lb n="5"/><rs ana="WINAQ_BALAM_AKNUEVE">Vinac bam</rs>
-                    <!-- </p> -->
+                    
                 </p>
                 <p n="100">
-                    <!-- <p xml:id="p95"> -->
+                    
                     <lb n="6" rend="indent"/><hi rend="large">A</hi>recut ahauab ri chuvach
                     <lb n="7"/><rs ana="AJAW_K'ICHE'">ahau quiche</rs> are vleel vtazel
                     <lb n="8"/>puch arecut vbi ahauab va

--- a/data/lit0001/pw0001/lit0001.pw0001.popolwuj-quc.xml
+++ b/data/lit0001/pw0001/lit0001.pw0001.popolwuj-quc.xml
@@ -25,7 +25,7 @@
                 <pubPlace>Chicago, Illinois, USA</pubPlace>
                 <pubPlace>Iximulew</pubPlace>
                 <availability>
-                    <license><!-- Still being resolved --></license>
+                    <licence><!-- Still being resolved --></licence>
                 </availability>
             </publicationStmt>
             <sourceDesc>

--- a/data/lit0001/pw0001/lit0001.pw0001.popolwuj-quc.xml
+++ b/data/lit0001/pw0001/lit0001.pw0001.popolwuj-quc.xml
@@ -47,7 +47,7 @@
             <refsDecl n="CTS">
                 <cRefPattern n="section" 
                              matchPattern="(\w+)" 
-                             replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
+                             replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:p[@n='$1'])">
                 <p>pointer pattern extracting paragraph</p>
                 </cRefPattern>
             </refsDecl>
@@ -70,11 +70,11 @@
     <text n="urn:cts:mayaLit:lit0001.pw0001.popolwuj-quc:" xml:id="MS1515v2">
         <body xml:lang="quc" n="urn:cts:mayaLit:lit0001.pw0001.popolwuj-quc:">
             <div type="column">
-                <div type="section" subtype="paragraph" n="1">
+                <p n="1">
                   <lb n="1" /><hi rend="very-large">ARE V XE OHER</hi>
                   <lb n="2" rend="hanging"/>Ꜩih varal Quiche vbi.
-                </div>
-                <div type="section" subtype="paragraph" n="2">
+                </p>
+                <p n="2">
                     <lb n="3" rend="indent"/><hi rend="large">V</hi>aral xchicaꜩibah vi xchica<pc> –</pc>
                     <lb n="4" />tiquiba vi oher ꜩih, vticaribal,
                     <lb n="5" />vxenabal puch ronohel xban,
@@ -122,8 +122,8 @@
                     <!-- <pb xml:id="xom-f01-s2" /> -->
                     <lb n="47"/>ato qol vi cah vleu cho palo
                     <lb n="48"/>
-                </div>
-                <div type="section" subtype="paragraph" n="3">
+                </p>
+                <p n="3">
                     <!-- <p xml:id="p03"> -->
                     <lb n="2" rend="center"/><hi rend="large">ARE V ꜨIHOXIC VAE</hi>
                     <lb n="3" rend="center"/>Cacaꜩinin oc, caca chamam oc
@@ -131,8 +131,8 @@
                     <lb n="5" rend="center"/>lolinic, catolona puch v
                     <lb n="6" rend="center"/>pa cah.
                     <!-- </p> -->
-               </div>
-               <div type="section" subtype="paragraph" n="4">
+               </p>
+               <p n="4">
                     <!-- <p xml:id="p04"> -->
                     <lb n="7" rend="indent"/><hi rend="large">V</hi>ae cute nabe ꜩih nabe vch<pc> –</pc>
                     <lb n="8"/>an. mahabi oꜫ hun vinac, hun
@@ -161,8 +161,8 @@
                     <lb n="31"/>ch <rs ana="UK'U'X_KAJ">vqux cah</rs> are vbi ri ca<pc> –</pc>
                     <lb n="32"/>bauil chuqhaxic.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="5">
+                </p>
+                <p n="5">
                     <!-- <p xml:id="p05"> -->
                     <lb n="33" rend="indent"/><hi rend="large">T</hi>a xpe cut vꜩih varal xul
                     <lb n="34"/>cuq ri <rs ana="TEPEW_Q'UKUMATZ">tepeu gucumaꜩ</rs> varal
@@ -229,8 +229,8 @@
                     <!-- <pb xml:id="xom-f02-s2"/> -->
                     <lb n="1"/>tahic cumal.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="6">
+                </p>
+                <p n="6">
                     <!-- <p xml:id="p06"> -->
                     <note><num>2</num></note>
                     <lb n="2" rend="indent"/><hi rend="large">T</hi>a xquinohih chic vchicop<pc> –</pc>
@@ -265,8 +265,8 @@
                     <lb n="31"/>lom</rs>. xuꜩininaca chic ronohel
                     <lb n="32"/>ri queh ꜩiquin
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="7">
+                </p>
+                <p n="7">
                     <!-- <p xml:id="p07"> -->
                     <lb n="33" rend="indent"/><hi rend="large">T</hi>a xevqhax chicut rÿ queh
                     <lb n="34"/>ꜩiquin rumal <rs ana="TZACOL">ꜩacol</rs> <rs ana="BITOL">bitol</rs> <rs ana="ALOM">a<pc> –</pc>
@@ -369,8 +369,8 @@
                     <lb n="35"/>are qui bi ri <rs ana="XPIYAKOK">xpiyacoc</rs>, <rs ana="IXMUKANE">xmuca<pc> –</pc>
                     <lb n="36"/>ne</rs>
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="8">
+                </p>
+                <p n="8">
                     <!-- <p xml:id="p08"> -->
                     <lb n="37" rend="indent"/><hi rend="large">X</hi>eqha qu ri <rs ana="UK'U'X_KAJ">huracan</rs> ruq <rs ana="TEPEW_Q'UKUMATZ">te<pc> –</pc>
                     <lb n="38"/>peu gucumaꜩ</rs> ta xquibih chire<pc> –</pc>
@@ -449,8 +449,8 @@
                     <lb n="14"/>enabe ꜩaꜩ chivinac xevxic
                     <lb n="15"/>varal chuvach vleu
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="9">
+                </p>
+                <p n="9">
                     <!-- <p xml:id="p09"> -->
                     <lb n="16" rend="indent"/><hi rend="large">C</hi>atecut qui quÿzic chic qui
                     <lb n="17"/>mayxic qui cutuxic puch xe
@@ -554,8 +554,8 @@
                     <lb n="13"/>hule vinac ꜩac, vinac bit
                     <lb n="14"/>xapoy, xapu ahamche.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="10">
+                </p>
+                <p n="10">
                     <!-- <p xml:id="p10"> -->
                     <lb n="15" rend="indent"/><hi rend="large">A</hi>re cut xa hubic zac na
                     <lb n="15.1"/>tanoh vvachvleu mahabi
@@ -607,8 +607,8 @@
                     <lb n="12"/>xchacatahic, ta xbanatahic vi<pc> –</pc>
                     <lb n="13"/>nac rumal <rs ana="TZ'AQOL">ahꜩac</rs>, <rs ana="BITOL">ahbit</rs>.
                     <!-- </p> -->
-                </div> 
-                <div type="section" subtype="paragraph" n="11">
+                </p> 
+                <p n="11">
                     <!-- p xml:id="p11" -->
                     <lb n="14" rend="indent"/><hi rend="large">V</hi>ae vxe vchacatahic v yi<pc> –</pc>
                     <lb n="15"/>coxic chi puch v quih <rs ana="WUQUB_KAKIX">vucub
@@ -668,8 +668,8 @@
                     <lb n="19"/>cut xnohix vi qui camic qui
                     <lb n="20"/>zachic cumal <rs ana="KA'IB_K'AJOLAB">qaholab</rs>.
                      <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="12">
+                </p>
+                <p n="12">
                     <!-- <p xml:id="p12"> -->
                     <lb n="21" rend="indent"/><hi rend="large">V</hi>ae cute v vbaxic vvcub
                     <lb n="22"/>caquix cumal caib <rs ana="KA'IB_K'AJOLAB">qaholab</rs>
@@ -840,8 +840,8 @@
                     <lb n="38"/>be chic e caib <rs ana="KA'IB_K'AJOLAB">qaholab</rs>, xa vꜩih
                     <lb n="39"/>ri <rs ana="UK'U'X_KAJ">vqux cah</rs> ta xquibano.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="13">
+                </p>
+                <p n="13">
                     <!-- <p xml:id="p13"> -->
                     <lb n="40"/><hi rend="large">V</hi>ae chi cute vbanoh chic <rs ana="SIPAKNA">zi<pc> –</pc>
                     <lb n="41"/>pacna</rs> v nabe qahol <rs ana="WUQUB_KAKIX">vvcub<pc> –</pc>
@@ -987,8 +987,8 @@
                     <lb n="34"/><rs ana="KA'IB_K'AJOLAB">qaholab</rs> <rs ana="JUNAJPU">hun ahpu</rs>, <rs ana="XBALAMKE">xbalan<pc> –</pc>
                     <lb n="35"/>que</rs>.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="14">
+                </p>
+                <p n="14">
                     <!-- <p xml:id="p14"> -->
                     <lb n="36" rend="indent"/><hi rend="large">A</hi>re chic vchacatahic, v
                     <lb n="37"/>camic <rs ana="SIPAKNA">zipacna</rs>, ta xchac chic
@@ -1094,8 +1094,8 @@
                     <lb n="41"/>rizai rib. hun chi cut xchica<pc> –</pc>
                     <lb n="42"/>bÿh vbixic
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="15">
+                </p>
+                <p n="15">
                     <!-- <p xml:id="p15"> -->
                     <lb rend="indent" n="43"/><hi rend="large">R</hi>ox chicut nimarizai rib v
                     <lb n="44"/>cab v qahol <rs ana="WUQUB_KAKIX">vvcub caquix</rs> <rs ana="KABRAQAN">cab<pc> –</pc>
@@ -1219,8 +1219,8 @@
                     <lb n="17"/><rs ana="SIPAKNA">zipacna</rs>, ruq <rs ana="KABRAQAN">cabracan</rs>, varal
                     <lb n="18"/>chuvach vleuh.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="16">
+                </p>
+                <p n="16">
                     <!-- <p xml:id="p16"> -->
                     <lb n="19" rend="indent"/><hi rend="large">A</hi>re chicut xchicabÿh chic v
                     <lb n="20"/>bi qui cahau ri <rs ana="JUNAJPU">hun ahpu</rs> <rs ana="XBALAMKE">xbalan
@@ -1230,8 +1230,8 @@
                     <lb n="24"/>xa nicah xchicabÿh, xa chacab v
                     <lb n="25"/>bixic quicahau.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="17">
+                </p>
+                <p n="17">
                     <!-- <p xml:id="p17"> -->
                     <lb n="26" rend="indent"/><hi rend="large">V</hi>ae cute vꜩihoxic. are qui bi
                     <lb n="27"/>ri <rs ana="JUN_JUNAJPU">hunhunahpu</rs>, que vqhaxic are
@@ -1341,8 +1341,8 @@
                     <lb n="34"/>chouen</rs> cumal <rs ana="JUNAJPU">hun ahpu</rs> <rs ana="XBALAMKE">xba<pc> –</pc>
                     <lb n="35"/>lanque</rs>.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="18">
+                </p>
+                <p n="18">
                     <!-- <p xml:id="p18"> -->
                     <lb n="36" rend="indent" /><hi>C</hi>ate cut qui petic zamahel ru
                     <lb n="37"/>mal <rs ana="JUN_KAME">hun came</rs>, <rs ana="WUQUB_KAME">vvcub came</rs> quix
@@ -1413,8 +1413,8 @@
                     <lb n="5"/>xbizonic xeqha ta xebec <rs ana="JUN_JUNAJPU">hun hu<pc> –</pc>
                     <lb n="6"/>nahpu</rs>, <rs ana="WUQUB_JUNAJPU">vvcub hun ahpu</rs>.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="19">
+                </p>
+                <p n="19">
                     <!-- <p xml:id="p19"> -->
                     <lb n="7" rend="indent" /><hi>C</hi>ate puch ta xebec <rs ana="JUN_JUNAJPU">hun hun<pc> –</pc>
                     <lb n="8"/>ahpu</rs>, <rs ana="WUQUB_JUNAJPU">vvcub hun ahpu</rs> xcamqui<pc> –</pc>
@@ -1573,15 +1573,15 @@
                     <lb n="14"/>ta hun <rs ana="IXKIK'">capoh</rs>. va cute xchicabÿh
                     <lb n="15"/>roponic.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="20">
+                </p>
+                <p n="20">
                     <!-- <p xml:id="p20"> -->
                     <lb n="16" rend="indent"/><hi rend="large">V</hi>a chi cute vꜩihoxic hun capoh
                     <lb n="17"/><rs ana="IXKIK'">vmeal</rs> hun ahau <rs ana="KUCHUMA_KIK'">cuchumaquic</rs>
                     <lb n="18"/>vbi.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="21">
+                </p>
+                <p n="21">
                     <!-- <p xml:id="p21"> -->
                     <lb n="19" rend="indent"/><hi rend="large">A</hi>re cut ta xuta hun <rs ana="IXKIK'">capoh vme<pc> –</pc>
                     <lb n="20"/>al</rs> hun ahau <rs ana="KUCHUMA_KIK'">cuchumaquic</rs> vbi v
@@ -1653,8 +1653,8 @@
                     <lb n="32"/>vcahau ri <rs ana="KUCHUMA_KIK'">cuchumaquic</rs> vbi v
                     <lb n="33"/>cahau
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="22">
+                </p>
+                <p n="22">
                     <!-- <p xml:id="p22"> -->
                     <lb n="34" rend="indent"/><hi rend="large">C</hi>ate puch vnatahic capoh ru<pc> –</pc>
                     <lb n="35"/>mal vcahau ta xil ri ral cochic
@@ -1753,8 +1753,8 @@
                     <lb n="28"/>ri rumal <rs ana="IXKIK'">capoh</rs> xemoyvachixic
                     <lb n="29"/>conohel.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="23">
+                </p>
+                <p n="23">
                     <!-- <p xml:id="p23"> -->
                     <lb n="30" rend="indent"/><hi rend="large">A</hi>re cut e qo ri <rs ana="IXMUKANE">vchuch</rs> <rs ana="JUN_BATZ'">hun baꜩ</rs>
                     <lb n="31"/><rs ana="JUN_CHOWEN">hun choven</rs> ta xul ri ixoc <rs ana="IXKIK'">xquic</rs> v
@@ -1835,14 +1835,14 @@
                     <lb n="7"/>china abanoh ri eqorivi enavinac
                     <lb n="8"/>chic xuqhax cut <rs ana="IXKIK'">capoh</rs>
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="24">
+                </p>
+                <p n="24">
                     <!-- <p xml:id="p24"> -->
                     <lb n="9" rend="indent"/><hi rend="large">A</hi>re chic xchicaꜩihoh calaxic
                     <lb n="10"/><rs ana="JUNAJPU">hun ahpu</rs> <rs ana="XBALAMKE">xbalanque</rs>
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="25">
+                </p>
+                <p n="25">
                     <!-- <p xml:id="p25"> -->
                     <lb n="11" rend="indent"/><hi rend="large">A</hi>re cut calaxic vae xchicabÿh
                     <lb n="12"/>ta xuric vquih calaxic taxalan
@@ -1983,8 +1983,8 @@
                     <lb n="41"/>quitiquiba zuanic, <rs ana="JUNAJPU">hun ahpu</rs> x coy
                     <lb n="42"/>xquizuah.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="26">
+                </p>
+                <p n="26">
                     <!-- <p xml:id="p26"> -->
                     <lb n="43" rend="indent"/><hi rend="large">C</hi>atepuch xebixanic xezuanic
                     <lb n="44"/>xe cohomanic ta vcamic riqui zu
@@ -2058,8 +2058,8 @@
                     <lb n="12"/>nim chic xquibano ta xecoheic rug
                     <lb n="13"/>ratit rug pu quichuch
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="27">
+                </p>
+                <p n="27">
                     <!-- <p xml:id="p27"> -->
                     <lb n="14" rend="indent"/><hi rend="large">T</hi>a x quitiquiba chicut quibanoh
                     <lb n="15"/>qui cutbal quib chuvach catit chu<pc> –</pc>
@@ -2223,8 +2223,8 @@
                     <lb n="20"/>oh ri <rs ana="JUNAJPU">hun ahpu</rs> <rs ana="XBALAMKE">xbalanque</rs> qui
                     <lb n="21"/>cutiquil quih xeoponic.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="28">
+                </p>
+                <p n="28">
                     <!-- <p xml:id="p28"> -->
                     <lb n="22" rend="indent"/><hi rend="large">M</hi>acu calah richo cucaam
                     <lb n="23"/>taxeoponic hunriyacalic xoc
@@ -2274,8 +2274,8 @@
                     <lb n="14"/>vach catit quehe cut vcanaic quic
                     <lb n="15"/>ri.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="29">
+                </p>
+                <p n="29">
                     <!-- <p xml:id="p29"> -->
                     <lb n="16" rend="indent"/><hi rend="large">Q</hi>uequicot chicut xebec echaa
                     <lb n="17"/>hel, pahom nahtcu xechaahic qui
@@ -2368,8 +2368,8 @@
                     <lb n="2"/>naquipa ri choquic petaca vvb xe
                     <lb n="3"/>qha.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="30">
+                </p>
+                <p n="30">
                     <!-- <p xml:id="p30"> -->
                     <lb n="4" rend="indent" /><hi rend="large">C</hi>atepuch xquivvbah ri <rs ana="PAJARO">vac</rs> qui<pc> –</pc>
                     <lb n="5"/>cutacal vbaca vvb chu baca vvach
@@ -2430,8 +2430,8 @@
                     <lb n="9"/>petic xeopon cut ruq <rs ana="IXMUKANE">catit</rs> xa
                     <lb n="10"/>e pixabai chire <rs ana="IXMUKANE">catit</rs> xebec.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="31">
+                </p>
+                <p n="31">
                     <!-- <p xml:id="p31"> -->
                     <lb n="11" rend="indent"/>ho na <rs ana="IXMUKANE">ixcatit</rs> xaohpixabay
                     <lb n="12"/>ive vae cute retal caꜩih xchicacanah
@@ -2756,8 +2756,8 @@
                     <lb n="20"/>vzbala xeqha <rs ana="KA'IB_K'AJOLAB">qaho<pc> –</pc>
                     <lb n="21"/>lab</rs> ta x que leh.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="32">
+                </p>
+                <p n="32">
                     <!-- <p xml:id="p32"> -->
                     <lb n="22"/>Xeoc chicut pa<rs ana="XUXULIM_JA">teuh ha</rs> ma<pc> –</pc>
                     <lb n="23"/>ui ahilan teu ꜩaꜩ chi zacbocom
@@ -2776,8 +2776,8 @@
                     <lb n="36"/>banoh <rs ana="KA'IB_K'AJOLAB">qaholab</rs> <rs ana="XBALAMKE">xba<pc> –</pc>
                     <lb n="37"/>lan que</rs>
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="33">
+                </p>
+                <p n="33">
                     <!-- <p xml:id="p33"> -->
                     <lb n="38" rend="indent" />Cate xeoc chicut <rs ana="BALAM_JA">pabala
                     <lb n="39"/>mi ha</rs> ꜩaꜩ chibalam balam
@@ -2797,8 +2797,8 @@
                     <lb n="5"/>qui xepe vi xeqha ri  co<pc> –</pc>
                     <lb n="6"/>nohel
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="34">
+                </p>
+                <p n="34">
                     <!-- <p> -->
                     <lb n="7"/>Cate chic xeoc chupam <rs ana="JA_CHI_Q'AQ'">ꜫaꜫ
                     <lb n="8"/>hun ha</rs> chiꜫaꜫ, xa vtu que l ꜫaꜫ v
@@ -2810,8 +2810,8 @@
                     <lb n="14"/>ui que he xavi
                     <lb n="15"/>cazach quiqux rumal.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="35">
+                </p>
+                <p n="35">
                     <!-- <p xml:id="p35"> -->
                     <lb n="16"/>Xecoh chic chupan <rs ana="SOTZ'I_JA">zoꜩin ha</rs>
                     <lb n="17"/>vtu que l zoꜩ chupam chiha
@@ -2913,8 +2913,8 @@
                     <lb n="14"/>xzaquiric xavi xare vꜩqui<pc> –</pc>
                     <lb n="15"/>vach qui cabichal.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="36">
+                </p>
+                <p n="36">
                     <!-- <p xml:id="p36"> -->
                     <lb n="16" rend="indent" />xcah chicu quichaah colan
                     <lb n="17"/>chicu vholom <rs ana="JUNAJPU">hun ahpu</rs> chuvi
@@ -2968,8 +2968,8 @@
                     <lb n="14"/>ui are xecam vi ri ronohel
                     <lb n="15"/>xban chique.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="37">
+                </p>
+                <p n="37">
                     <!-- <p xml:id="p37"> -->
                     <lb n="16" rend="indent" /><hi rend="large">A</hi>Are cut vae quinabal qui<pc> –</pc>
                     <lb n="17"/>camic <rs ana="JUNAJPU">hun ahpu</rs> <rs ana="XBALAMKE">xbalanque</rs> are
@@ -3062,8 +3062,8 @@
                     <lb n="5"/>vxic xavi xere qui vach xuxic
                     <lb n="6"/>xecutun chicut.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="38">
+                </p>
+                <p n="38">
                     <!-- <p xml:id="p38"> -->
                     <lb n="7" rend="indent" />Chi robix cut xecutun chix xe
                     <lb n="8"/>il chi ya rumal vinac e caib que
@@ -3091,8 +3091,8 @@
                     <lb n="30"/>v xenaahic chic chacbal quech
                     <lb n="31"/><rs ana="XIBALBA">xibalba</rs> cumal.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="39">
+                </p>
+                <p n="39">
                     <!-- <p xml:id="p39"> -->
                     <lb n="32" rend="indent" />Cate chi puch roponic chic v
                     <lb n="33"/>ꜩihel quixahoh chi xiquin aha<pc> –</pc>
@@ -3131,8 +3131,8 @@
                     <lb n="18"/>zamahel chiquivach camol que
                     <lb n="19"/>ta xebe cut ruq ahau.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="40">
+                </p>
+                <p n="40">
                     <!-- <p xml:id="p40"> -->
                     <lb n="20" rend="indent" />Xeopon puch cuq ahauab
                     <lb n="21"/>Quemocho chic chiqui xule la
@@ -3221,8 +3221,8 @@
                     <lb n="5"/><rs ana="JUN_KAME">huncame</rs> <rs ana="WUQUB_KAME">vvcub came</rs> queheri
                     <lb n="6"/>are quexahovic caquinao.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="41">
+                </p>
+                <p n="41">
                     <!-- <p xml:id="p41"> -->
                     <lb n="7" rend="indent" />Cate puch vrainic vmalinic
                     <lb n="8"/>pu quiqux ahauab chire qui
@@ -3274,8 +3274,8 @@
                     <lb n="3"/>qui bi, xquicobizah quib chi<pc> –</pc>
                     <lb n="4"/>qui vach conohel <rs ana="XIBALBA">xibalba</rs>.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="42">
+                </p>
+                <p n="42">
                     <!-- <p xml:id="p42"> -->
                     <lb n="5" rend="indent" />Chitaa cabi xchicabÿh. xch<pc> –</pc>
                     <lb n="6"/>icabÿh naipuch vbi cacahau
@@ -3361,8 +3361,8 @@
                     <lb n="38"/>cahau chiquetax xquichac <rs ana="XIBALBA">xi<pc> –</pc>
                     <lb n="39"/>balba</rs>.  <note resp="editor">somehow left out of flat, added by me </note>
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="43">
+                </p>
+                <p n="43">
                     <!-- <p xml:id="p43"> -->
                     <lb n="40" rend="indent"/>Vacute vviquic chic qui ca<pc> –</pc>
                     <lb n="41"/>hau cumal are xquivic ri <rs ana="WUQUB_JUNAJPU">vvcub
@@ -3401,8 +3401,8 @@
                     <lb n="23"/><rs ana="SIPAKNA">zipacna</rs> are cut cachbil xu<pc> –</pc>
                     <lb n="24"/>xic e vchumilal cah xevxic.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="44">
+                </p>
+                <p n="44">
                     <!-- <p xml:id="p44"> -->
                     <lb n="25" rend="indent"/><hi rend="large">V</hi>ae cut vtiqueric ta xnaohix
                     <lb n="26"/>vinac ta xꜩucux puch ri choc vtio<pc> –</pc>
@@ -3423,14 +3423,14 @@
                     <lb n="41"/>ui cauachin quih ic chumil pa
                     <lb n="42"/>qui vi e <rs ana="TZ'AQOL">ꜩacol</rs> <rs ana="BITOL">bitol</rs>.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="45">
+                </p>
+                <p n="45">
                     <!-- <p xml:id="p45"> -->
                     <lb n="43" rend="indent"/><hi rend="large">P</hi>an <rs ana="PAXIL">paxil</rs>, pan <rs ana="K'AYALA'">cayala</rs> vbi xpe
                     <lb n="44"/>vi eanahal zaquihal.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="46">
+                </p>
+                <p n="46">
                     <!-- <p xml:id="p46"> -->
                     <lb n="45" rend="indent"/><hi rend="large">A</hi>re cuquibi chicop va camolre
                     <lb n="46"/>cha. yac, vtiu, quel, hoh ecahib
@@ -3468,8 +3468,8 @@
                     <lb n="29"/>hau e cahib chivinac ꜩac xa
                     <lb n="30"/>echa oquinac quitiohil.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="47">
+                </p>
+                <p n="47">
                     <!-- <p xml:id="p47"> -->
                     <lb n="31" rend="indent"/><hi rend="large">V</hi>ae quibi naabe vinac xeꜩa<pc> –</pc>
                     <lb n="32"/>quic xebitic. are nabe vinac ri
@@ -3478,8 +3478,8 @@
                     <lb n="35"/>vcah cut <rs ana="IK'I_BALAM">Iquibalam</rs>. are cu
                     <lb n="36"/>quibi ri canabe chuch cahau.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="48">
+                </p>
+                <p n="48">
                     <!-- <p xml:id="p48"> -->
                     <lb n="37" rend="indent"/>Xa ꜩac xa bit que vqhaxic
                     <lb n="38"/>mahabi quichuch mahabi qui<pc> –</pc>
@@ -3517,8 +3517,8 @@
                     <lb n="19"/>vinac ri <rs ana="BALAM_KI'TZE'">balam quiꜩe</rs>, <rs ana="BALAM_AQ'AB">Balam<pc> –</pc>
                     <lb n="20"/>acab</rs>, <rs ana="MAJUK'UTAJ">mahucutah</rs>, <rs ana="IK'I_BALAM">iquibalam</rs>.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="49">
+                </p>
+                <p n="49">
                     <!-- <p xml:id="p49"> -->
                     <lb n="21" rend="indent"/>Ta xeꜩonox cut rumal ri
                     <lb n="22"/><rs ana="TZ'AQOL">ahꜩac</rs> <rs ana="BITOL">ahbit</rs> huchalic iqohei
@@ -3550,8 +3550,8 @@
                     <pb xml:id="xom-f34-s1"/>
                     <lb n="1"/>chutin queqha.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="50">
+                </p>
+                <p n="50">
                     <!-- <p xml:id="p50"> -->
                     <lb n="2" rend="indent"/>Quehe chicut vcamic chic
                     <lb n="3"/>qui naoh <rs ana="ALOM">alom</rs> <rs ana="K'AJOLOM">qaholom</rs> hucha
@@ -3575,8 +3575,8 @@
                     <lb n="21"/>col</rs> <rs ana="BITOL">bitol</rs> quevqhaxic ta xquiban
                     <lb n="22"/>cut vqoheic chic quiꜩac qui bit
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="51">
+                </p>
+                <p n="51">
                     <!-- <p xml:id="p51"> -->
                     <lb n="23" rend="indent"/>Xaca xvabax vbac qui vach
                     <lb n="24"/>rumal ri <rs ana="UK'U'X_KAJ">vqux cah</rs> xmoyic quehe<pc> –</pc>
@@ -3715,8 +3715,8 @@
                     <lb n="6"/><rs ana="IK'I_BALAM">iqui balam</rs> xquitao vꜩihol hun
                     <lb n="7"/>tinamit xebevi
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="52">
+                </p>
+                <p n="52">
                     <!-- <p xml:id="p52"> -->
                     <lb n="8" rend="indent"/><hi rend="large">A</hi>recut vbi huyub va xebe vi
                     <lb n="9"/><rs ana="BALAM_KI'TZE'">Balam quiꜩe</rs>, <rs ana="BALAM_AQ'AB">Balam acab</rs> <rs ana="MAJUK'UTAJ">mahu
@@ -3725,8 +3725,8 @@
                     <lb n="12"/>cubzivan vbi tinamit xeopon vi
                     <lb n="13"/>e camolre cabauil
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="53">
+                </p>
+                <p n="53">
                     <!-- <p xml:id="p53"> -->
                     <lb n="14" rend="indent"/>Xeopon cut chila <rs ana="TULÁN">tulan</rs> conoh<pc> –</pc>
                     <lb n="15"/>el maui ahilan chivinac xoponic
@@ -3752,8 +3752,8 @@
                     <lb n="35"/>quimam quicahau ahauab xa
                     <lb n="36"/>ui quetaam va camic
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="54">
+                </p>
+                <p n="54">
                     <!-- <p xml:id="p54"> -->
                     <lb n="37" rend="indent"/>Quehecut vbinaam vi ox<pc> –</pc>
                     <lb n="38"/>ib chiquiche xma xuꜩocopih
@@ -3805,8 +3805,8 @@
                     <lb n="35"/>mac quequicotic rumal qui
                     <lb n="36"/>ꜫaꜫ
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="55">
+                </p>
+                <p n="55">
                     <!-- <p xml:id="p55"> -->
                     <lb n="37" rend="indent" />Catepuch ta xticaric nima hab
                     <lb n="38"/>are catilo vꜫaꜫ amac ꜩaꜩ cut
@@ -3880,8 +3880,8 @@
                     <lb n="10"/>chiquimah quichi chiqui mah qui
                     <lb n="11"/>vach
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="56">
+                </p>
+                <p n="56">
                     <!-- <p xml:id="p56"> -->
                     <lb n="12"/>Cate puch culic chic e eloeom
                     <lb n="13"/>chiquivach <rs ana="BALAM_KI'TZE'">balam quiꜩe</rs>, <rs ana="BALAM_AQ'AB">balam
@@ -3993,8 +3993,8 @@
                     <lb n="22"/>qui hunam vach xeicou vla
                     <lb n="23"/>chila <rs ana="NIM_XO'L">nim xol</rs> cabixic vacamic
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="57">
+                </p>
+                <p n="57">
                     <!-- <p xml:id="p57"> -->
                     <lb n="24"/>Taxevl puch chiri chuvi hun
                     <lb n="25"/>huyub chiri xquicuch vi quib
@@ -4012,8 +4012,8 @@
                     <lb n="37"/>xahunam caꜩih xeqhacut
                     <lb n="38"/>ta xcoh quibi
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="58">
+                </p>
+                <p n="58">
                     <!-- <p> -->
                     <lb n="39"/>Ta xbinaah chicuri <rs ana="KAQCHIKELEB">ꜫaꜫche<pc> –</pc>
                     <lb n="40"/>queleb</rs>. <rs ana="KAQCHIKELEB">ꜫaꜫchequeleb</rs> vbi xuxic
@@ -4062,8 +4062,8 @@
                     <lb n="35"/><rs ana="CHI_PIXAB">chipixab</rs> vbi vacamic xqha
                     <lb n="36"/>chi cut qui cabauil chiri.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="59">
+                </p>
+                <p n="59">
                     <!-- <p xml:id="p59"> -->
                     <lb n="37"/>Ta xqha cut ruq <rs ana="TOJIL">tohil</rs> <rs ana="AWILIX">au<pc> –</pc>
                     <lb n="38"/>lix</rs> <rs ana="JAQAWITZ">hacaviꜩ</rs> chiquech ri <rs ana="BALAM_KI'TZE'">Ba<pc> –</pc>
@@ -4175,14 +4175,14 @@
                     <pb xml:id="xom-f40-s1"/>
                     <lb n="1"/>chinic puch quih, ic, qhumil
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="60">
+                </p>
+                <p n="60">
                     <!-- <p xml:id="p60"> -->
                     <lb n="2" rend="indent"/>Vae cute vzaquiric vvachi<pc> –</pc>
                     <lb n="3"/>nic puch quih, ic, qhumil.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="61">
+                </p>
+                <p n="61">
                     <!-- <p xml:id="p61"> -->
                     <lb n="4" rend="indent"/><hi rend="large">N</hi>im cut xe quicotic <rs ana="BALAM_KI'TZE'">balam
                     <lb n="5"/>quiꜩe</rs>, <rs ana="BALAM_AQ'AB">balam acab</rs>, <rs ana="MAJUK'UTAJ">mahucutah</rs>,
@@ -4331,8 +4331,8 @@
                     <lb n="4"/>caviꜩ</rs> areqochic pa ec pa ꜩi<pc> –</pc>
                     <lb n="5"/>yac cumal.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="62">
+                </p>
+                <p n="62">
                     <!-- <p xml:id="p62"> -->
                     <lb n="6" rend="indent"/>Vacute quicatonic vxe chipu<pc> –</pc>
                     <lb n="7"/>ch cohbal rech <rs ana="TOJIL">tohil</rs> ta xebe
@@ -4457,15 +4457,15 @@
                     <lb n="30"/>qui hab rib riquic xuxic vyaon
                     <lb n="31"/><rs ana="TOJIL">tohil</rs> ruq <rs ana="AWILIX">aulix</rs> x <rs ana="JAQAWITZ">hacaviꜩ</rs>.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="63">
+                </p>
+                <p n="63">
                     <!-- <p xml:id="p63"> -->
                     <lb n="32" rend="indent"/><hi rend="large">V</hi>ae vticaric chic relecaxic vi<pc> –</pc>
                     <lb n="33"/>nac amac cumal <rs ana="BALAM_KI'TZE'">balam quiꜩe</rs>, <rs ana="BALAM_AQ'AB">ba
                     <lb n="34"/>lam acab</rs> <rs ana="MAJUK'UTAJ">mahucutah</rs> <rs ana="IK'I_BALAM">iqui balam</rs>.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="64">
+                </p>
+                <p n="64">
                     <!-- <p xml:id="p64"> -->
                     <lb n="35" rend="indent"/><hi rend="large">C</hi>ate puch vcamizaxic amac ri
                     <lb n="36"/>are xquicam ri xa hun chubinic
@@ -4523,8 +4523,8 @@
                     <lb n="40"/>vcamic vnaoh amac chire vca<pc> –</pc>
                     <lb n="41"/>mizaxic tah.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="65">
+                </p>
+                <p n="65">
                     <!-- <p xml:id="p65"> -->
                     <lb n="42" rend="indent"/><hi rend="large">N</hi>abe cut xrah qui naohih a<pc> –</pc>
                     <lb n="43"/>mac vchaquic <rs ana="TOJIL">tohil</rs> <rs ana="AWILIX">avlix</rs> <rs ana="JAQAWITZ">hacaviꜩ</rs>
@@ -4596,8 +4596,8 @@
                     <lb n="13" />tohil aulix hacaviꜩ</rs>. are qui
                     <lb n="14" />naoh ronohel amac rÿ.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="66">
+                </p>
+                <p n="66">
                     <!-- <p xml:id="p66"> -->
                     <lb n="15" rend="indent" />Cate puch xebec xecauuxic qui<pc> –</pc>
                     <lb n="16" />bec chila <rs ana="EL_BAÑO_DE_TOJIL">chatin vi tohil</rs> quicari<pc> –</pc>
@@ -4632,8 +4632,8 @@
                     <lb n="45" />hib</rs> rumal qui naual <rs ana="TOJIL">tohil</rs> xe
                     <lb n="46" />qha curi <rs ana="TOJIL">tohil</rs> <rs ana="AWILIX">aulix</rs> <rs ana="JAQAWITZ">hacaviꜩ</rs>
                     <!-- </p> -->f
-                </div>
-                <div type="section" subtype="paragraph" n="67">
+                </p>
+                <p n="67">
                     <!-- <p> -->
                     <pb xml:id="xom-f44-s2"/>
                     <lb n="1"/>ta xeqhau chic chiquech ri xtah
@@ -4651,8 +4651,8 @@
                     <lb n="13"/>chique xevqhax cut <rs ana="BALAM_KI'TZE'">balam qui<pc> –</pc>
                     <lb n="14"/>ꜩe</rs>, <rs ana="BALAM_AQ'AB">balam acab</rs>, <rs ana="MAJUK'UTAJ">mahucutah</rs>.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="68">
+                </p>
+                <p n="68">
                     <!-- <p xml:id="p67"> -->
                     <lb n="15" rend="indent"/>Cate cut xezibanic coxichal na<pc> –</pc>
                     <lb n="16"/>be xꜩiban ri <rs ana="BALAM_KI'TZE'">balam quiꜩe</rs>. balam
@@ -4747,8 +4747,8 @@
                     <lb n="9"/>quicuch quib conohel xepoponic
                     <lb n="10"/>xeta co quib conohel.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="69">
+                </p>
+                <p n="69">
                     <!-- <p xml:id="p68"> -->
                     <lb n="11" rend="indent"/><hi>V</hi>ae cute qui molouic quib co<pc> –</pc>
                     <lb n="12"/>nohel amac e cauutal chic chi
@@ -4854,8 +4854,8 @@
                     <lb n="16"/>e qo vi are cut coquibexic va xchi
                     <lb n="17"/>cabÿh chic
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="70">
+                </p>
+                <p n="70">
                     <!-- <p xml:id="p69"> -->
                     <lb n="18" rend="indent"/><hi>A</hi>re cut e qo chiri <rs ana="BALAM_KI'TZE'">balam quiꜩe</rs>
                     <lb n="19"/><rs ana="BALAM_AQ'AB">balam acab</rs> <rs ana="MAJUK'UTAJ">mahucutah</rs> <rs ana="IK'I_BALAM">iqui ba<pc> –</pc>
@@ -4933,8 +4933,8 @@
                     <lb n="43"/>quiꜩe</rs> <rs ana="BALAM_AQ'AB">balam acab</rs>, <rs ana="MAKUJUTAJ">mahucutah</rs>
                     <lb n="44"/><rs ana="IK'I_BALAM">iqui balam</rs> qui bi.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="71">
+                </p>
+                <p n="71">
                     <!-- <p xml:id="p70"> -->
                     <lb n="45" rend="indent"/><hi>X</hi>quina cut qui camic qui zachic
                     <lb n="46"/>ta xepixabic chirech qui qahol ma
@@ -5026,8 +5026,8 @@
                     <lb n="36"/>varal taxecamic erih chic e
                     <lb n="37"/>ahquixb ahcahb quibinaam.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="72">
+                </p>
+                <p n="72">
                     <!-- <p xml:id="p71"> -->
                     <lb n="38" rend="indent" />Cate puch taxquiquxlaah qui<pc> –</pc>
                     <lb n="39"/>bÿc chila relebal quih are qui
@@ -5063,8 +5063,8 @@
                     <lb n="18"/>biahau va rahaual ahrele<pc> –</pc>
                     <lb n="19"/>bal quih xeoponvi.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="73">
+                </p>
+                <p n="73">
                     <!-- <p xml:id="p72"> -->
                     <lb n="20" rend="indent" /><hi rend="large">T</hi>a xeopon cut chuvach ahau
                     <lb n="21"/><rs ana="NAKXIT">nacxit</rs> vbi nim ahau xahu
@@ -5086,8 +5086,8 @@
                     <lb n="37"/>vꜩibal xeqha chire qui oqui<pc> –</pc>
                     <lb n="38"/>nac chupan chupan quiꜩih.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="74">
+                </p>
+                <p n="74">
                     <!-- <p xml:id="p73"> -->
                     <lb n="39" rend="indent" />Cate puch ta xevlic chiri chu<pc> –</pc>
                     <lb n="40"/>ui quitinamit <rs ana="JAQAWITZ_JUYUB">hacaviꜩ</rs> vbi chi<pc> –</pc>
@@ -5156,8 +5156,8 @@
                     <lb n="3"/>cahauixel va cu vbi tinamit
                     <lb n="4"/>e xevl vi
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="75">
+                </p>
+                <p n="75">
                     <!-- <p xml:id="p74"> -->
                     <lb n="5"/><rs ana="CHI_ISMACHI">Chiizmachi</rs> cut vbihuyub qui
                     <lb n="6"/>tinamit xeqohe vi chinaipuchxe
@@ -5276,8 +5276,8 @@
                     <lb n="15"/>chic taxquil puch hunchic tina<pc> –</pc>
                     <lb n="16"/>mit xcocotah chivi ri <rs ana="CHI_ISMACHI">chiizmachi</rs>.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="76">
+                </p>
+                <p n="76">
                     <!-- <p xml:id="p75"> -->
                     <lb n="17"/>Catepuch taxeyacatah chivl
                     <lb n="18"/>oc xevlchiri patinamit <rs ana="Q'UMARAQ_AJ">cumarca<pc> –</pc>
@@ -5333,8 +5333,8 @@
                     <lb n="16"/>cabÿh quibi riahauab chuhu<pc> –</pc>
                     <lb n="17"/>hunal huhun vnim ha.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="77">
+                </p>
+                <p n="77">
                     <!-- <p xml:id="p76"> -->
                     <lb n="18" rend="indent" /><hi rend="large">V</hi>ae cute quibi ahauab chu
                     <lb n="19"/>vach <rs ana="KAWEQ">caui quib</rs> are nabe ahau
@@ -5344,16 +5344,16 @@
                     <lb n="23"/>queh nay</rs>. <rs ana="POPOL_WINAQ_PA_JOM_TZALATZ'">popol vinac, pahom
                     <lb n="24"/>ꜩalaꜩ</rs>, vchuch cam ha.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="78">
+                </p>
+                <p n="78">
                     <!-- <p xml:id="p77"> -->
                     <lb n="25" rend="indent" /><hi rend="large">A</hi>re cut ahauab ri chuvach
                     <lb n="26"/><rs ana="KAWEQ">caviquib</rs> beleheb chi ahauab
                     <lb n="27"/>colehe vnimha chuhuhunal ca
                     <lb n="28"/>te chic chivachin v vach.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="79">
+                </p>
+                <p n="79">
                     <!-- <p xml:id="p78"> -->
                     <lb n="29" rend="indent" /><hi rend="large">A</hi>re chicu ahavab va chu
                     <lb n="30"/>vach <rs ana="NIJA'IB">nihaibab</rs> are nabe aha<pc> –</pc>
@@ -5365,8 +5365,8 @@
                     <lb n="36"/>beleheb cut chi ahauab chuva<pc> –</pc>
                     <lb n="37"/>ch <rs ana="NIJA'IB">nihaibab</rs>
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="80">
+                </p>
+                <p n="80">
                     <!-- <p xml:id="p79"> -->
                     <lb n="38" rend="indent" /><hi rend="large">A</hi>re chicut ahau quiche va
                     <lb n="39"/>vae quibi ahauab. ahꜩic vinac
@@ -5375,8 +5375,8 @@
                     <lb n="42"/>hauab chuvach <rs ana="AJAW_K'ICHE'">ahau quiche</rs><pc> –</pc>
                     <lb n="43"/>eb colehe vnim ha.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="81">
+                </p>
+                <p n="81">
                     <!-- <p xml:id="p80"> -->
                     <lb n="44"/>Ca<gap reason="deletion" unit="character" instant="false"/>ib chinamit chi na ipuch
                     <lb n="45"/>ca quiquib au<add place="above" instant="false" status="unremarkable">ha</add>ab <rs ana="TZUTUJA">ꜩutuha</rs>
@@ -5384,8 +5384,8 @@
                     <lb n="46"/>'zaquic</rs> xahun chi nim ha ecaib
                     <lb n="47"/>chiahauab.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="82">
+                </p>
+                <p n="82">
                     <!-- <p xml:id="p81"> -->
                     <pb xml:id="xom-f51-s2"/>
                     <note  place="margin-left" type="pagination" anchored="true">
@@ -5464,8 +5464,8 @@
                     <lb n="23"/>bano role ahau xuxic xaui xe
                     <lb n="24"/>qaholanic hutac le chiahauab.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="83">
+                </p>
+                <p n="83">
                     <!-- <p xml:id="p82"> -->
                     <lb n="25" rend="indent"/>Va chicute quibÿ chic vvac
                     <lb n="26"/>le ahau e caib chinimac aha<pc> –</pc>
@@ -5519,8 +5519,8 @@
                     <lb n="23"/>zivan rih tinamit xcahinac ocv
                     <lb n="24"/>tinamit ronohel amac.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="84">
+                </p>
+                <p n="84">
                     <!-- <p xml:id="p83"> -->
                     <lb n="25" rend="indent"/>Catecut ta relic varanel ilol
                     <lb n="26"/>ahlabal ta xquiba cut vvachinel
@@ -5605,15 +5605,15 @@
                     <lb n="6"/>cut runohel qo pa huhun chihu<pc> –</pc>
                     <lb n="7"/>yub xa hun xecuchvi.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="85">
+                </p>
+                <p n="85">
                     <!-- <p xml:id="p84"> -->
                     <lb n="8" rend="indent"/><rs ana="XE_BALAX">Xebalax</rs>, <rs ana="XE_KAMAQ">xecamac</rs> vbi huyub
                     <lb n="9"/>xechap vi taxoc qui calem chiri
                     <lb n="10"/><rs ana="CHULIMAL">chulimal</rs> xbanvi
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="86">
+                </p>
+                <p n="86">
                     <!-- <p xml:id="p85"> -->
                     <lb n="11" rend="indent"/>Va cute qui cobic qui chapic
                     <lb n="12"/>quetaxic puch huvinac ealel hu
@@ -5639,8 +5639,8 @@
                     <lb n="32"/>pop</rs> ahpop camha chirih puchca<pc> –</pc>
                     <lb n="33"/>lel <rs ana="AJTZIK_WINAQ">ahꜩicvinac</rs> xelvi
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="87">
+                </p>
+                <p n="87">
                     <!-- <p xml:id="p86"> -->
                     <lb n="34" rend="indent"/><hi rend="large">A</hi>recut xchicabÿhchic vbiro
                     <lb n="35"/>choch cabauil xavi xere xubi<pc> –</pc>
@@ -5702,8 +5702,8 @@
                     <lb n="43"/>vach qui cabauil taqueꜩononic
                     <lb n="44"/>are cut roqueh qui quxva
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="88">
+                </p>
+                <p n="88">
                     <!-- <p xml:id="p87"> -->
                     <lb n="45" rend="indent"/><hi rend="large">A</hi>carroc atoob vquih, <rs ana="HURACAN">athu<pc> –</pc>
                     <lb n="46"/>racan</rs>, <rs ana="UK'U'X_KAJ_UK'U'X_ULEW">at vquxcah vleu</rs>, at ya<pc> –</pc>
@@ -5785,8 +5785,8 @@
                     <lb n="23"/>ahavab ruq quibi conohel aha<pc> –</pc>
                     <lb n="24"/>uab xchicabÿh chic.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="89">
+                </p>
+                <p n="89">
                     <!-- <p xml:id="p88"> -->
                     <lb n="25" rend="indent"/><hi rend="large">V</hi>ae cute vleel, vtazel aha<pc> –</pc>
                     <lb n="26"/>uarem chi ronohel quizaquiri<pc> –</pc>
@@ -5805,8 +5805,8 @@
                     <lb n="39"/>cate xchivachin vvach huhun chuhu<pc> –</pc>
                     <lb n="40"/>hunal ahauab quiche
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="list" n="90">
+                </p>
+                <p n="90">
                     <!-- <p> -->
                     <lb n="41" rend="indent"/><rs ana="BALAM_KI'TZE'"><hi rend="large">B</hi>alam quiꜩe</rs> vxe nabal <rs ana="KAWEQ">cavi
                     <lb n="42" rend="hanging"/>quib</rs>
@@ -5867,8 +5867,8 @@
                     <lb n="20"/>cablahu le ahauab eqahola<pc> –</pc>
                     <lb n="21"/>xel rumal <rs ana="TEKUM_TRECE">tecum</rs> <rs ana="TEPEPUL_TRECE">tepepul</rs>
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="91">
+                </p>
+                <p n="91">
                     <!-- <p xml:id="p89"> -->
                     <lb n="22"/><hi rend="large">A</hi>recut vleel vtazel ahauarem
                     <lb n="23"/>ri ahau <rs ana="AJPOP">ahpop</rs> <rs ana="AJPOP_K'AMJA">ahpop camba</rs> chu<pc> –</pc>
@@ -5880,8 +5880,8 @@
                     <lb n="29"/>uiquib</rs> beleheb vnimha va tac
                     <lb n="30"/>vbi e rahaual huhun chi nimha.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="list" n="92">
+                </p>
+                <p n="92">
                     <!-- <p> -->
                     <lb n="31"/><hi rend="large">A</hi>hau ahpop hun vnimha cuhavbi
                     <lb n="32" rend="hanging" />nimha
@@ -5912,15 +5912,15 @@
                     <!-- <p> -->
                     <lb n="42"/><rs ana="YAKI_TEPEW"><hi rend="large">T</hi>epeu iaqui</rs> hun vnimha
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="93">
+                </p>
+                <p n="93">
                     <!-- <p xml:id="p90"> -->
                     <lb n="43" rend="indent" /><hi rend="large">A</hi>re curi bele heb <rs ana="SAQIK">chinamit</rs> chi<pc> –</pc>
                     <lb n="44"/>cavi quib ꜩaꜩ ral vqahol ahilatal
                     <lb n="45"/>chirih beleheb chinim ha
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="94">
+                </p>
+                <p n="94">
                     <!-- <p xml:id="p91"> -->
                     <lb n="46"/><hi rend="large">V</hi>acute rech <rs ana="NIJA'IB">nihaibab</rs> beleheb
                     <lb n="47"/>chivi chinimha are nabe xchica<pc> –</pc>
@@ -5929,8 +5929,8 @@
                     <lb n="2"/>hun vxe x<add place="above" instant="false" status="unremarkable">ch</add>ticar  chuvach vxe
                     <lb n="3"/>quih vxe zac chivinac
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="list" n="95">
+                </p>
+                <p n="95">
                     <!-- <p> -->
                     <lb n="4"/><rs ana="BALAM_AQ'AB "><hi rend="large">B</hi>alam acab</rs> nabe mamaxel ca
                     <lb n="5" rend="hanging"/>hauixel.
@@ -5975,16 +5975,16 @@
                     <lb n="20"/><rs ana="DON_PEDRO_DE_ROBLES_NJDOCE"><hi rend="large">z<choice><abbr>D</abbr><expan instant="false">Don</expan></choice></hi>. Pedro de robles</rs> <rs ana="AJAQ_Q'ALEL_NJDOCE">ahau ꜫalel</rs>
                     <lb n="21"/>vacamic.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="96">
+                </p>
+                <p n="96">
                     <!-- <p xml:id="p92"> -->
                     <lb n="22" rend="indent"/><hi rend="large">A</hi>re curi chi ronobel ahavab
                     <lb n="22.1"/>elenac chirih ri <rs ana="AJAW_Q'ALEL">ahau ꜫalel</rs> are
                     <lb n="22.2"/>chic xchicabÿh rahaual huhun
                     <lb n="22.3"/>chinim ha.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="list" n="97">
+                </p>
+                <p n="97">
                     <!-- <p> -->
                     <lb n="23"/><note place="margin-left" anchored="true"><hi rend="handwriting;color:pencil"><num>1</num></hi></note><rs ana="AJAW_Q'ALEL"><hi rend="large">A</hi>hau ꜫalel</rs> vnabe ahau chuva<pc> –</pc>
                     <lb n="24" rend="indent"/>ch <rs ana="NIJA'IB">nihaibab</rs> hun vnim ha.
@@ -6013,8 +6013,8 @@
                     <!-- <p> -->
                     <lb n="32"/><note place="margin-left" anchored="true"><hi rend="handwriting;color:pencil"><num>9</num></hi></note><rs ana="YAKOLATAM"><hi rend="large">Y</hi>acolatam</rs> hun vnim ha.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="98">
+                </p>
+                <p n="98">
                     <!-- <p xml:id="p93"> -->
                     <lb n="33" rend="indent"/><hi rend="large">A</hi>recut nim ha ri chuvach <rs ana="NIJA'IB">ni<pc> –</pc>
                     <lb n="34"/>haibab</rs> are vbinaam vi beleheb
@@ -6023,8 +6023,8 @@
                     <lb n="37"/>hun chique ahauab are vnabe
                     <lb n="38"/>ri mi xcabÿ quibi.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="99">
+                </p>
+                <p n="99">
                     <!-- <p xml:id="p94"> -->
                     <lb n="39" rend="indent"/><hi rend="large">A</hi>re chicut rech <rs ana="AJAW_K'ICHE'">ahau qui che</rs>
                     <lb n="40"/>va vmam vcahau
@@ -6040,8 +6040,8 @@
                     <lb n="4"/><rs ana="K'OYABAKOJ_AKOCHO">Coyabacoh</rs>
                     <lb n="5"/><rs ana="WINAQ_BALAM_AKNUEVE">Vinac bam</rs>
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="100">
+                </p>
+                <p n="100">
                     <!-- <p xml:id="p95"> -->
                     <lb n="6" rend="indent"/><hi rend="large">A</hi>recut ahauab ri chuvach
                     <lb n="7"/><rs ana="AJAW_K'ICHE'">ahau quiche</rs> are vleel vtazel
@@ -6049,8 +6049,8 @@
                     <lb n="9"/>chupan nimha xacahib vnim
                     <lb n="10"/>ha.
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="list" n="101">
+                </p>
+                <p n="101">
                     <!-- <p> -->
                     <lb n="11"/><rs ana="AJAW_AJTZIK_WINAQ"><hi rend="large">A</hi>h ꜩic vinac ahau</rs> vbi nabeahau
                     <lb n="12" rend="indent"/>hun vnim ha
@@ -6063,8 +6063,8 @@
                     <lb n="18" rend="indent"/>vnim ha chicahibcut nimha
                     <lb n="19" rend="indent"/>chuvach <rs ana="AJAW_K'ICHE'">ahau quiche</rs>
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="102">
+                </p>
+                <p n="102">
                     <!-- <p xml:id="p96"> -->
                     <lb n="20" rend="indent"/><hi rend="large">A</hi>re curi e oxib chinim chocoh
                     <lb n="21"/>queheri e cahauixel rumal ro<pc> –</pc>
@@ -6074,8 +6074,8 @@
                     <lb n="25"/>evcahau ꜩih nim zcaquin vqo<pc> –</pc>
                     <lb n="26"/>heic eoxib chichocohib
                     <!-- </p> -->
-                </div>
-                <div type="section" subtype="paragraph" n="103">
+                </p>
+                <p n="103">
                     <!-- <p xml:id="p97"> -->
                     <lb n="27" rend="indent"/><hi rend="large">N</hi>im chocohcut chuvach <rs ana="NIJA'IB">nihaib</rs>
                     <lb n="28"/>vcab curi. <rs ana="AJAW_NIM_CH'OKOJ">nimchocoh ahau</rs> chuva<pc> –</pc>
@@ -6099,7 +6099,7 @@
                     <lb/>
                     <lb/>
                     <!-- </p> -->
-                </div> 
+                </p> 
             </div>
         </body>
     </text>

--- a/data/lit0001/pw0001/lit0001.pw0001.popolwuj-quc.xml
+++ b/data/lit0001/pw0001/lit0001.pw0001.popolwuj-quc.xml
@@ -628,7 +628,7 @@
                     <lb n="45"/>camob</rs> <rs ana="JULISNAB">huliznab</rs> chuchaxic
                     <lb n="46"/>vbi huiub xqolic ta chi za<pc> –</pc>
                     <lb n="47"/>quiric xa hun aꜫab chi vi-
-                    <!-- <pb xml:id="xom-f06-s2"/> -->
+                    <pb xml:id="xom-f06-s2"/>
                     <note resp="editor">The number 6 in the margin is in a different hand and ink (pencil?) </note>
                     <lb n="1"/>naquiric rumal ri <rs ana="SIPAKNA">zipacna</rs>
                     <note place="left-margin" anchored="true"><num rend="large">6</num></note>
@@ -651,10 +651,8 @@
                     <lb n="18"/>chuch canabe cahau quehe
                     <lb n="19"/>cut xnohix vi qui camic qui
                     <lb n="20"/>zachic cumal <rs ana="KA'IB_K'AJOLAB">qaholab</rs>.
-                     <!-- </p> -->
                 </p>
                 <p n="12">
-                    <!-- <p xml:id="p12"> -->
                     <lb n="21" rend="indent"/><hi rend="large">V</hi>ae cute v vbaxic vvcub
                     <lb n="22"/>caquix cumal caib <rs ana="KA'IB_K'AJOLAB">qaholab</rs>
                     <lb n="23"/>xch<del rend="scribble" instant="false" status="unremarkable">i</del> cabÿh qui chacatahic
@@ -685,7 +683,7 @@
                     <lb n="45"/>be vqhapa, cate cut ta x<pc> –</pc>
                     <lb n="46"/>cupix vla veab ri<rs ana="JUNAJPU">hun hu
                     <lb n="47"/>nahpu</rs> rumal ri <rs ana="WUQUB_KAKIX">vvcub ca
-                    <!-- <pb xml:id="xom-f07-s1"/> -->
+                    <pb xml:id="xom-f07-s1"/>
                     <lb n="1"/>quix</rs>, huzuc xꜩac vloc, xme<pc> –</pc>
                     <lb n="2"/>ho vloc, ꜩam vteleb ta xuꜩo<pc> –</pc>
                     <lb n="3"/>copih chi cut <rs ana="JUNAJPU">hunhunahpu</rs>
@@ -823,10 +821,8 @@
                     <lb n="37"/>nimarizabal ib cate cut xe
                     <lb n="38"/>be chic e caib <rs ana="KA'IB_K'AJOLAB">qaholab</rs>, xa vꜩih
                     <lb n="39"/>ri <rs ana="UK'U'X_KAJ">vqux cah</rs> ta xquibano.
-                    <!-- </p> -->
                 </p>
                 <p n="13">
-                    <!-- <p xml:id="p13"> -->
                     <lb n="40"/><hi rend="large">V</hi>ae chi cute vbanoh chic <rs ana="SIPAKNA">zi<pc> –</pc>
                     <lb n="41"/>pacna</rs> v nabe qahol <rs ana="WUQUB_KAKIX">vvcub<pc> –</pc>
                     <lb n="42"/>caquix</rs>, in banol huyub ca<pc> –</pc>
@@ -970,10 +966,8 @@
                     <lb n="33"/>chic <rs ana="SIPAKNA">zipacna</rs> rumal ri e caib
                     <lb n="34"/><rs ana="KA'IB_K'AJOLAB">qaholab</rs> <rs ana="JUNAJPU">hun ahpu</rs>, <rs ana="XBALAMKE">xbalan<pc> –</pc>
                     <lb n="35"/>que</rs>.
-                    <!-- </p> -->
                 </p>
                 <p n="14">
-                    <!-- <p xml:id="p14"> -->
                     <lb n="36" rend="indent"/><hi rend="large">A</hi>re chic vchacatahic, v
                     <lb n="37"/>camic <rs ana="SIPAKNA">zipacna</rs>, ta xchac chic
                     <lb n="38"/>cumal ri e caib <rs ana="KA'IB_K'AJOLAB">qaholab</rs> <rs ana="JUNAJPU">hun
@@ -1077,10 +1071,8 @@
                     <lb n="40"/>ual xchacatah vi. vcab nima<pc> –</pc>
                     <lb n="41"/>rizai rib. hun chi cut xchica<pc> –</pc>
                     <lb n="42"/>bÿh vbixic
-                    <!-- </p> -->
                 </p>
                 <p n="15">
-                    <!-- <p xml:id="p15"> -->
                     <lb rend="indent" n="43"/><hi rend="large">R</hi>ox chicut nimarizai rib v
                     <lb n="44"/>cab v qahol <rs ana="WUQUB_KAKIX">vvcub caquix</rs> <rs ana="KABRAQAN">cab<pc> –</pc>
                     <lb n="45"/>rracan</rs> vbi in yohol huiub xqha.
@@ -1202,10 +1194,8 @@
                     <lb n="16"/>chacatahic <rs ana="WUQUB_KAKIX">vvcub caquix</rs>, ruc
                     <lb n="17"/><rs ana="SIPAKNA">zipacna</rs>, ruq <rs ana="KABRAQAN">cabracan</rs>, varal
                     <lb n="18"/>chuvach vleuh.
-                    <!-- </p> -->
                 </p>
                 <p n="16">
-                    <!-- <p xml:id="p16"> -->
                     <lb n="19" rend="indent"/><hi rend="large">A</hi>re chicut xchicabÿh chic v
                     <lb n="20"/>bi qui cahau ri <rs ana="JUNAJPU">hun ahpu</rs> <rs ana="XBALAMKE">xbalan
                     <lb n="21"/>que</rs> <del rend="scribble" instant="false" status="unremarkable">p</del>xcacamuh chuvi xapu xca<pc> –</pc>
@@ -1213,10 +1203,8 @@
                     <lb n="23"/>qaholaxic ri <rs ana="JUNAJPU">hun ahpu</rs> <rs ana="XBALAMKE">xbalanq’</rs>
                     <lb n="24"/>xa nicah xchicabÿh, xa chacab v
                     <lb n="25"/>bixic quicahau.
-                    <!-- </p> -->
                 </p>
                 <p n="17">
-                    <!-- <p xml:id="p17"> -->
                     <lb n="26" rend="indent"/><hi rend="large">V</hi>ae cute vꜩihoxic. are qui bi
                     <lb n="27"/>ri <rs ana="JUN_JUNAJPU">hunhunahpu</rs>, que vqhaxic are
                     <lb n="28"/>cut qui cahau ri <rs ana="XPIYAKOK">xpiyacoc</rs> <rs ana="IXMUKANE">xmu<pc> –</pc>
@@ -1324,10 +1312,8 @@
                     <lb n="33"/>qui chacatahic chic <rs ana="JUN_BATZ'">hun baꜩ</rs> <rs ana="JUN_CHOWEN">hun
                     <lb n="34"/>chouen</rs> cumal <rs ana="JUNAJPU">hun ahpu</rs> <rs ana="XBALAMKE">xba<pc> –</pc>
                     <lb n="35"/>lanque</rs>.
-                    <!-- </p> -->
                 </p>
                 <p n="18">
-                    <!-- <p xml:id="p18"> -->
                     <lb n="36" rend="indent" /><hi>C</hi>ate cut qui petic zamahel ru
                     <lb n="37"/>mal <rs ana="JUN_KAME">hun came</rs>, <rs ana="WUQUB_KAME">vvcub came</rs> quix
                     <lb n="38"/>bec ixrah popachih he i taca ri
@@ -1396,10 +1382,8 @@
                     <lb n="4"/>cane</rs>. hona mahabi cohcamic mi<pc> –</pc>
                     <lb n="5"/>xbizonic xeqha ta xebec <rs ana="JUN_JUNAJPU">hun hu<pc> –</pc>
                     <lb n="6"/>nahpu</rs>, <rs ana="WUQUB_JUNAJPU">vvcub hun ahpu</rs>.
-                    <!-- </p> -->
                 </p>
                 <p n="19">
-                    <!-- <p xml:id="p19"> -->
                     <lb n="7" rend="indent" /><hi>C</hi>ate puch ta xebec <rs ana="JUN_JUNAJPU">hun hun<pc> –</pc>
                     <lb n="8"/>ahpu</rs>, <rs ana="WUQUB_JUNAJPU">vvcub hun ahpu</rs> xcamqui<pc> –</pc>
                     <lb n="9"/>be cumal ri zamahel, ta xecah<pc> –</pc>
@@ -1556,14 +1540,11 @@
                     <lb n="13"/>vbi xuxic, nim cut vꜩihoxic xu<pc> –</pc>
                     <lb n="14"/>ta hun <rs ana="IXKIK'">capoh</rs>. va cute xchicabÿh
                     <lb n="15"/>roponic.
-                    <!-- </p> -->
                 </p>
                 <p n="20">
-                    <!-- <p xml:id="p20"> -->
                     <lb n="16" rend="indent"/><hi rend="large">V</hi>a chi cute vꜩihoxic hun capoh
                     <lb n="17"/><rs ana="IXKIK'">vmeal</rs> hun ahau <rs ana="KUCHUMA_KIK'">cuchumaquic</rs>
                     <lb n="18"/>vbi.
-                    <!-- </p> -->
                 </p>
                 <p n="21">
                     <!-- <p xml:id="p21"> -->


### PR DESCRIPTION
There was an issue with  validation because of the use of <div> element as paragraphs elements in the paragraphs and topics edition. This change was reflected in the refsDecl element as well.